### PR TITLE
logging: improve reliability of real time logs

### DIFF
--- a/api/ext/q5-functions/src/routes/middleware/authorize.js
+++ b/api/ext/q5-functions/src/routes/middleware/authorize.js
@@ -17,14 +17,22 @@ module.exports = function authorize_factory(options) {
     }
     const data = { token, subscription: '12345' };
     const url = `${usersServiceUrl}/authorize`;
-
-    request({ method: 'POST', url, data }).then(response => {
-      if (response.status !== 200) {
-        next(create_error(403));
-      } else {
-        next();
-      }
-    });
+    request({
+      method: 'POST',
+      url,
+      data,
+      validateStatus: status => (status >= 200 && status < 300) || status === 403,
+    })
+      .then(response => {
+        if (response.status !== 200) {
+          next(create_error(403));
+        } else {
+          next();
+        }
+      })
+      .catch(e => {
+        next(create_error(500, 'Unable to authenticate the caller: ' + e.message));
+      });
   };
 
   function getTokenFromAuthorizationHeader(req) {

--- a/demo/sales-anchor/sales-anchor-app/src/comp/Main.tsx
+++ b/demo/sales-anchor/sales-anchor-app/src/comp/Main.tsx
@@ -9,7 +9,7 @@ import { Notifications } from './Notifications';
 import { SideNav } from './SideNav';
 
 enum Selections {
-  newInquiries = 'New Inquiries',
+  newInquiries = 'Leads',
   eventActions = 'Event Actions',
 }
 

--- a/lib/client/q5-editor/src/Server.ts
+++ b/lib/client/q5-editor/src/Server.ts
@@ -105,7 +105,10 @@ export class Server {
           nodejs: workspace.functionSpecification.nodejs,
           metadata: workspace.functionSpecification.metadata,
         };
-        if (workspace.functionSpecification.schedule) {
+        if (
+          workspace.functionSpecification.schedule &&
+          Object.keys(workspace.functionSpecification.schedule).length > 0
+        ) {
           params.schedule = workspace.functionSpecification.schedule;
         }
         return Superagent.put(url)

--- a/lib/server/q5-functions-lambda/lambda/executor.js
+++ b/lib/server/q5-functions-lambda/lambda/executor.js
@@ -2,6 +2,14 @@ var Assert = require('assert');
 var handler = require('./app/index');
 var Util = require('util');
 
+var config = {
+  backoffRandomOffsetRange: +process.env.Q5_LOGS_WS_INITIAL_BACKOFF_RANDOM_OFFSET_RANGE || 2000,
+  initialBackoff: +process.env.Q5_LOGS_WS_INITIAL_BACKOFF || 500,
+  backoffRatio: +process.env.Q5_LOGS_WS_BACKOFF_RATIO || 1.2,
+  maxBackoff: +process.env.Q5_LOGS_WS_MAX_BACKOFF || 60000,
+  maxBuffer: +process.env.Q5_LOGS_WS_MAX_BUFFER || 100,
+};
+
 var bunyanLevels = {
   stdout: 30,
   stderr: 50,
@@ -9,76 +17,117 @@ var bunyanLevels = {
   error: 50,
 };
 
-var ws = undefined;
+// real-time logs
+var realTimeLogsSetup = false;
+var currentWs = undefined;
+var currentBackoff = config.initialBackoff;
 var applicationName;
 var buffer = [];
+var latestLogs;
 
 exports.execute = function execute(event, context, cb) {
-  return !ws && event.logs ? setupRealTimeLogs() : processRequest();
+  latestLogs = event.logs || latestLogs;
+  return !realTimeLogsSetup && event.logs ? setupRealTimeLogs(event, context, cb) : processRequest(event, context, cb);
+};
 
-  function processRequest() {
-    try {
-      Assert.equal(typeof handler, 'function', 'The module export must be a function.');
-      Assert.equal(handler.length, 2, 'The function must take two parameters: (ctx, cb).');
+function processRequest(event, context, cb) {
+  try {
+    Assert.equal(typeof handler, 'function', 'The module export must be a function.');
+    Assert.equal(handler.length, 2, 'The function must take two parameters: (ctx, cb).');
 
-      if (ws) {
-        hookupConsole(console, 'log');
-        hookupConsole(console, 'error');
-      }
-
-      event.configuration = process.env;
-
-      return handler(event, cb);
-    } catch (e) {
-      console.error('EXECUTION ERROR', e);
-      return cb(e);
+    if (realTimeLogsSetup) {
+      hookupConsole(console, 'log');
+      hookupConsole(console, 'error');
     }
+
+    event.configuration = process.env;
+
+    return handler(event, cb);
+  } catch (e) {
+    console.error('EXECUTION ERROR', e);
+    return cb(e);
   }
+}
 
-  function setupRealTimeLogs() {
-    const WebSocket = require('ws');
-    var nextCalled;
+function setupRealTimeLogs(event, context, cb) {
+  realTimeLogsSetup = true;
+  process.nextTick(function() {
+    startLogsExport(event);
+  });
+  return processRequest(event, context, cb);
+}
 
-    applicationName = 'application:' + event.boundary + ':' + event.name;
-    ws = new WebSocket(event.logs.url, { headers: { Authorization: 'Bearer ' + event.logs.token } });
-    ws.once('open', next);
-    ws.once('error', next);
-    ws.once('close', next);
-    hookupStream('stdout');
-    hookupStream('stderr');
-    return processRequest();
+function startLogsExport(event) {
+  const WebSocket = require('ws');
+  applicationName = 'application:' + event.boundary + ':' + event.name;
 
-    function next() {
-      if (nextCalled) return;
-      nextCalled = true;
+  hookupStream('stdout');
+  hookupStream('stderr');
+
+  return connect();
+
+  function connect() {
+    var ws = new WebSocket(latestLogs.url, { headers: { Authorization: 'Bearer ' + latestLogs.token } });
+    ws.once('open', function() {
       try {
         ws._socket.unref(); // prevent Lambda process from hanging on this open socket
       } catch (_) {}
-      if (ws.readyState === 1) {
-        buffer.forEach(send);
-        buffer = undefined;
+      currentWs = ws;
+      flushLogs();
+    });
+    ws.once('error', onClose);
+    ws.once('close', onClose);
+    var onCloseCalled;
+    function onClose() {
+      if (onCloseCalled) return;
+      onCloseCalled = true;
+      currentWs = undefined;
+
+      // reconnect with exponential backoff with a cap and a random initial offset
+      var effectiveBackoff = currentBackoff;
+      if (effectiveBackoff === config.initialBackoff) {
+        effectiveBackoff += Math.floor(Math.random() * config.backoffRandomOffsetRange);
       }
+      currentBackoff = Math.min(Math.floor(currentBackoff * config.backoffRatio), config.maxBackoff);
+      setTimeout(connect, effectiveBackoff).unref();
     }
   }
-};
+}
+
+function flushLogs() {
+  if (currentWs && currentWs.readyState === 1) {
+    for (var msg = buffer.shift(); msg; msg = buffer.shift()) {
+      try {
+        currentWs.send(msg);
+      } catch (_) {}
+    }
+  }
+}
 
 function hookupStream(stream) {
   var oldWrite = process[stream].write;
   process[stream].write = function(chunk, encoding, callback) {
-    if (typeof chunk === 'string' && ws.readyState < 2) {
-      var msg = JSON.stringify({
-        name: applicationName,
-        level: bunyanLevels[stream],
-        msg: chunk,
-        time: new Date().toISOString(),
-      });
-      if (ws.readyState === 0) {
-        // connecting
-        buffer.push(msg);
-      } else if (ws.readyState === 1) {
-        // open
-        send(msg);
+    if (typeof chunk === 'string') {
+      if (buffer.length < config.maxBuffer) {
+        buffer.push(
+          JSON.stringify({
+            name: applicationName,
+            level: bunyanLevels[stream],
+            msg: chunk,
+            time: new Date().toISOString(),
+          })
+        );
+      } else if (buffer.length === config.maxBuffer) {
+        buffer.push(
+          JSON.stringify({
+            name: applicationName,
+            level: bunyanLevels['stdout'],
+            msg: 'INTERNAL ERROR. SOME LOGS MAY BE MISSING BEYOND THIS POINT.',
+            time: new Date().toISOString(),
+          })
+        );
       }
+      flushLogs();
     }
     return oldWrite.call(process[stream], chunk, encoding, callback);
   };
@@ -87,27 +136,26 @@ function hookupStream(stream) {
 function hookupConsole(console, method) {
   var oldMethod = console[method];
   console[method] = function() {
-    if (ws.readyState < 2) {
-      var msg = JSON.stringify({
-        name: applicationName,
-        level: bunyanLevels[method],
-        msg: Util.format.apply(Util.format, arguments),
-        time: new Date().toISOString(),
-      });
-      if (ws.readyState === 0) {
-        // connecting
-        buffer.push(msg);
-      } else {
-        // open
-        send(msg);
-      }
+    if (buffer.length < config.maxBuffer) {
+      buffer.push(
+        JSON.stringify({
+          name: applicationName,
+          level: bunyanLevels[method],
+          msg: Util.format.apply(Util.format, arguments),
+          time: new Date().toISOString(),
+        })
+      );
+    } else if (buffer.length === config.maxBuffer) {
+      buffer.push(
+        JSON.stringify({
+          name: applicationName,
+          level: bunyanLevels['error'],
+          msg: 'INTERNAL ERROR. SOME LOGS MAY BE MISSING BEYOND THIS POINT.',
+          time: new Date().toISOString(),
+        })
+      );
     }
+    flushLogs();
     return oldMethod.apply(console, arguments);
   };
-}
-
-function send(msg) {
-  try {
-    ws.send(msg);
-  } catch (_) {}
 }

--- a/lib/server/q5-functions-lambda/src/create_function_worker.js
+++ b/lib/server/q5-functions-lambda/src/create_function_worker.js
@@ -236,7 +236,22 @@ function delete_user_function(options, cb) {
   );
 }
 
+const userFunctionLogsConfig = {
+  Q5_LOGS_WS_INITIAL_BACKOFF_RANDOM_OFFSET_RANGE: process.env.LOGS_WS_INITIAL_BACKOFF_RANDOM_OFFSET_RANGE || '2000',
+  Q5_LOGS_WS_INITIAL_BACKOFF: process.env.LOGS_WS_INITIAL_BACKOFF || '500',
+  Q5_LOGS_WS_BACKOFF_RATIO: process.env.LOGS_WS_BACKOFF_RATIO || '1.2',
+  Q5_LOGS_WS_MAX_BACKOFF: process.env.LOGS_WS_MAX_BACKOFF || '60000',
+  Q5_LOGS_WS_MAX_BUFFER: process.env.LOGS_WS_MAX_BUFFER || '100',
+};
+
 function create_user_function_impl(ctx, cb) {
+  let variables = {};
+  for (var k in ctx.options.configuration) {
+    variables[k] = ctx.options.configuration[k];
+  }
+  for (var k in userFunctionLogsConfig) {
+    variables[k] = userFunctionLogsConfig[k];
+  }
   let create_function_params = {
     FunctionName: Common.get_user_function_name(ctx.options),
     Description: Common.get_user_function_description(ctx.options),
@@ -244,7 +259,7 @@ function create_user_function_impl(ctx, cb) {
     Handler: 'executor.execute',
     MemorySize: ctx.options.lambda.memory_size,
     Timeout: ctx.options.lambda.timeout,
-    Environment: { Variables: ctx.options.configuration },
+    Environment: { Variables: variables },
     Code: {
       S3Bucket: process.env.AWS_S3_BUCKET,
       S3Key: ctx.options.internal.function_signed_url.key,


### PR DESCRIPTION
* Improve reliability of real-time logging with an exponential backoff reconnect logic to the WS endpoint within the lambda code and an in-memory buffering when disconnected (limited to 100 entries by default).
* Fix error handling in the q5-function authorization middleware.
* Fix Sales Anchor regression in the navigation panel after the revamp of terminology.