### PR TITLE
export flexd-mono ec2 logs and metrics to cloud watch

### DIFF
--- a/api/int/cron/src/executor.ts
+++ b/api/int/cron/src/executor.ts
@@ -45,6 +45,7 @@ export function executor(event: any, context: any, cb: any) {
     }
 
     function runIfExists(exists: boolean, cb: any) {
+      console.log(exists ? 'RUNNING CRON JOB' : 'SKIPPING CRON JOB', msg);
       if (!exists) {
         result.skipped.push(msg);
         return cb();

--- a/api/int/pubsub/src/PubSub.ts
+++ b/api/int/pubsub/src/PubSub.ts
@@ -31,7 +31,7 @@ export class PubSub {
     if (this.xsubSock) {
       throw new Error('Server is already started');
     }
-    this.logger = ZmqLogger.create({ zmqPublishUrl, zmqPublishLevel, name: 'pubsub' });
+    this.logger = ZmqLogger.create({ zmqPublishUrl, zmqPublishLevel, name: 'pubsub', zmqKeepStdoutStream: true });
 
     // The xsub listener is where pubs connect to
     this.xsubSock = Zmq.socket('xsub');

--- a/lib/server/aws-ec2/src/AwsEc2.ts
+++ b/lib/server/aws-ec2/src/AwsEc2.ts
@@ -56,9 +56,93 @@ apt-get update
 apt-get install -y docker-ce
 apt-get install -y awscli
 
+# Get docker image of Flexd
+
 $(aws ecr get-login --region ${region} --no-include-email)
 
 docker pull ${account}.dkr.ecr.${region}.amazonaws.com/${repo}:${tag}
+
+# Install and configure AWS Unified Cloud Watch Agent
+
+wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
+dpkg -i -E ./amazon-cloudwatch-agent.deb
+
+cat > /opt/aws/amazon-cloudwatch-agent/bin/config.json << EOF
+{
+	"logs": {
+		"logs_collected": {
+			"files": {
+				"collect_list": [
+					{
+						"file_path": "/var/log/syslog",
+						"log_group_name": "/flexd-mono/${deploymentName}",
+						"log_stream_name": "{instance_id}"
+					}
+				]
+			}
+		}
+	},
+	"metrics": {
+		"append_dimensions": {
+      "FlexdDeploymentName": "${deploymentName}",
+			"AutoScalingGroupName": "\\\${aws:AutoScalingGroupName}",
+			"ImageId": "\\\${aws:ImageId}",
+			"InstanceId": "\\\${aws:InstanceId}",
+			"InstanceType": "\\\${aws:InstanceType}"
+		},
+		"metrics_collected": {
+			"cpu": {
+				"measurement": [
+					"cpu_usage_idle",
+					"cpu_usage_iowait",
+					"cpu_usage_user",
+					"cpu_usage_system"
+				],
+				"metrics_collection_interval": 60,
+				"totalcpu": false
+			},
+			"disk": {
+				"measurement": [
+					"used_percent",
+					"inodes_free"
+				],
+				"metrics_collection_interval": 60,
+				"resources": [
+					"*"
+				]
+			},
+			"diskio": {
+				"measurement": [
+					"io_time"
+				],
+				"metrics_collection_interval": 60,
+				"resources": [
+					"*"
+				]
+			},
+			"mem": {
+				"measurement": [
+					"mem_used_percent"
+				],
+				"metrics_collection_interval": 60
+			},
+			"swap": {
+				"measurement": [
+					"swap_used_percent"
+				],
+				"metrics_collection_interval": 60
+			}
+		}
+	}
+}
+EOF
+
+# Register AWS Unified Cloud Watch Agent as a service and start it
+
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json -s
+systemctl start amazon-cloudwatch-agent.service
+
+# Set up Flexd service
 
 cat > /etc/systemd/system/docker.flexd.service << EOF
 [Unit]
@@ -71,15 +155,19 @@ TimeoutStartSec=0
 Restart=always
 ExecStart=/usr/bin/docker run -p ${launch.albApiPort}:${launch.apiPort} -p ${launch.albLogPort}:${
       launch.logPort
-    } --name flexd -rm --env-file /etc/systemd/system/docker.flexd.env ${account}.dkr.ecr.${region}.amazonaws.com/${repo}:${tag}
+    } --name flexd --rm --env-file /etc/systemd/system/docker.flexd.env ${account}.dkr.ecr.${region}.amazonaws.com/${repo}:${tag}
 
 [Install]
 WantedBy=multi-user.target
 EOF
 
+# Drop Flexd configuration file
+
 cat > /etc/systemd/system/docker.flexd.env << EOF
 ${require('fs').readFileSync(require('path').join(__dirname, '../../../../.aws.' + deploymentName + '.env'), 'utf8')}
 EOF
+
+# Start Flexd service
 
 systemctl start docker.flexd`;
 

--- a/lib/server/zmq-logger/src/ZmqLogger.ts
+++ b/lib/server/zmq-logger/src/ZmqLogger.ts
@@ -10,6 +10,7 @@ export { LogLevelString } from 'bunyan';
 export interface IZmqLoggerOptions extends Bunyan.LoggerOptions {
   zmqPublishUrl: string;
   zmqPublishLevel?: LogLevelString;
+  zmqKeepStdoutStream?: boolean;
 }
 
 // ----------------
@@ -17,7 +18,6 @@ export interface IZmqLoggerOptions extends Bunyan.LoggerOptions {
 // ----------------
 
 export class ZmqLogger extends Bunyan {
-
   public static create(options: IZmqLoggerOptions) {
     return new ZmqLogger(options);
   }
@@ -25,7 +25,7 @@ export class ZmqLogger extends Bunyan {
 
   private constructor(options: IZmqLoggerOptions) {
     const bunyanOptions = options as Bunyan.LoggerOptions;
-    if (!bunyanOptions.streams && !bunyanOptions.stream) {
+    if (!bunyanOptions.streams && !bunyanOptions.stream && !options.zmqKeepStdoutStream) {
       bunyanOptions.streams = [];
     }
     super(options);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "org": "5qtrs",
   "scripts": {


### PR DESCRIPTION
* added AWS Univeral Cloud Watch Agent to flexd-mono EC2 instances via user data
* all logs are exported to the log group `/flexd-mono/{deploymentName}`. The log streams are created on a per-instance basis
* retention on the log group is manually configured to 1 day
* modified zmqlogger to optionally output to stdout as well; using this to allow pubsub to generate logs that are captured by cloud watch
* some logging improvements in the CRON executor lambda