### PR TITLE
Fix #134. Loading Monaco workers cross-domain

### DIFF
--- a/demo/functions/functions-app/views/playground.ejs
+++ b/demo/functions/functions-app/views/playground.ejs
@@ -3,22 +3,12 @@
 <head>
 	<meta charset="utf-8" />
     <link rel="icon" type="image/svg" href="/img/logo-0.png">
-    <!--<link rel="apple-touch-icon" sizes="76x76" href="/img/apple-icon.png"> -->
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 
     <title>Flexd</title>
 
     <meta content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0' name='viewport' />
     <meta name="viewport" content="width=device-width" />
-
-	<!-- Bootstrap core CSS     -->
-	<link href="/css/bootstrap.min.css" rel="stylesheet" />
-	<link href="/css/paper-kit.css?v=2.1.0" rel="stylesheet"/>
-
-    <!--     Fonts and icons     -->
-    <link href='//fonts.googleapis.com/css?family=Montserrat:400,300,700' rel='stylesheet' type='text/css'>
-    <link href="//maxcdn.bootstrapcdn.com/font-awesome/latest/css/font-awesome.min.css" rel="stylesheet">
-    <link href="/css/nucleo-icons.css" rel="stylesheet">
 
     <style>
         html,body {
@@ -32,9 +22,8 @@
     <div id="editor" style="width:800px;height:500px;margin-top:30px;margin-left:auto;margin-right:auto">
 </body>
 
-<script src="/js/jquery-3.2.1.js" type="text/javascript"></script>
-<script src="/js/popper.js" type="text/javascript"></script>
-<script src="/js/bootstrap.min.js" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js" type="text/javascript"></script>
+<!-- <script src="https://cdn.flexd.io/flexd/js/flexd-editor/latest/flexd-editor.js"></script> -->
 <script src="/js/<%- process.env.NODE_ENV === 'production' ? 'flexd-editor.min.js' : 'flexd-editor.js' %>" type="text/javascript"></script>
 <script type="text/javascript">
     $(function () {

--- a/lib/client/flexd-editor/package.json
+++ b/lib/client/flexd-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/flexd-editor",
-  "version": "0.0.1",
+  "version": "0.9.0",
   "description": "",
   "main": "libm/index.js",
   "browser": "libm/index.js",

--- a/lib/client/flexd-editor/src/index.ts
+++ b/lib/client/flexd-editor/src/index.ts
@@ -50,6 +50,21 @@ library.add(
 );
 dom.watch();
 
+// Work around issues related to loading Monaco workers cross-domain when the Flexd Editor
+// is hosted on CDN. This is based on Option 1 from
+// https://github.com/Microsoft/monaco-editor/blob/master/docs/integrate-amd-cross.md
+//@ts-ignore
+window.MonacoEnvironment = {
+  getWorkerUrl: function(workerId: string, label: string) {
+    return `data:text/javascript;charset=utf-8,${encodeURIComponent(`
+      self.MonacoEnvironment = {
+        baseUrl: 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.15.6/min/'
+      };
+      importScripts('https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.15.6/min/vs/base/worker/workerMain.js');`)}`;
+  },
+};
+
+export const version = require('../package.json').version;
 export * from './Server';
 export * from './Events';
 export * from './EditorContext';

--- a/lib/client/flexd-editor/webpack.config.js
+++ b/lib/client/flexd-editor/webpack.config.js
@@ -23,7 +23,6 @@ const config = {
   devtool: 'source-map',
   output: {
     path: join(__dirname, './dist'),
-    publicPath: process.env.Q5_PUBLIC_PATH || '/js/',
     filename: outputFile,
     library: 'flexd',
     libraryTarget: 'umd',


### PR DESCRIPTION
* Allow hosting Flexd Editor on CDN by working around the problem of loading Monaco workers cross-domain.
* Added `version` property to the flexd editor library so that we can always determine the version in the browser with `console.log(flexd.version)`. 