### PR TITLE
Fix #133. Minified version of the editor

### DIFF
--- a/demo/functions/functions-app/views/playground.ejs
+++ b/demo/functions/functions-app/views/playground.ejs
@@ -30,7 +30,7 @@
 
   <!-- <script src="https://cdn.fusebit.io/fusebit/js/fusebit-editor/latest/fusebit-editor.js"></script> -->
   <script
-    src="/js/<%- process.env.NODE_ENV === 'production' ? 'fusebit-editor.min.js' : 'fusebit-editor.js' %>"
+    src="/js/<%- process.env.NODE_ENV === 'production' ? 'fusebit-editor.min.js' : 'fusebit-editor.min.js' %>"
     type="text/javascript"
   ></script>
   <script type="text/javascript">

--- a/lib/client/fusebit-editor/package.json
+++ b/lib/client/fusebit-editor/package.json
@@ -1,17 +1,19 @@
 {
   "name": "@5qtrs/fusebit-editor",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "",
   "main": "libm/index.js",
   "browser": "libm/index.js",
   "module": "libm/index.js",
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "license": "UNLICENSED",
   "author": "FiveQuarters.io",
   "scripts": {
     "build": "tsc -b && cp ./src/*.css libm/",
     "lint": "tslint --fix -t stylish src/{,**/}*.ts{,x}",
-    "clean": "rm -r -f libm; rm -r -f dist; rm -r -f coverage",
+    "clean": "rm -r -f libm; rm -r -f dist; rm -r -f coverage; rm -f tsconfig.tsbuildinfo",
     "copy": "cp ./dist/* ../../../demo/functions/functions-app/assets/js/ && cp ./dist/* ../../../demo/sales-anchor/sales-anchor-app/js/",
     "bundle:dev": "webpack --env dev",
     "bundle:prod": "webpack --env build",

--- a/lib/client/fusebit-editor/src/index.ts
+++ b/lib/client/fusebit-editor/src/index.ts
@@ -70,6 +70,7 @@ export * from './Server';
 export * from './Events';
 export * from './EditorContext';
 export * from './CreateEditor';
+
 // export * from './CreateActionPanel';
 // export * from './CreateNavigationPanel';
 // export * from './CreateEditorPanel';

--- a/lib/client/fusebit-editor/webpack.config.js
+++ b/lib/client/fusebit-editor/webpack.config.js
@@ -16,6 +16,7 @@ if (env === 'build') {
 }
 
 const config = {
+  // stats: 'verbose',
   mode: mode,
   entry: {
     flexd: __dirname + '/libm/index.js',


### PR DESCRIPTION
The trick was to tell Terser (the minifier) that CSS files have side effects. Otherwise, it was excluding them from the bundle during tree shaking. This is done with `sideEffects: [ "*.css" ]` in package.json of fusebit-editor.