### PR TITLE
Fix #265. Support for IEditorOptions.ensureFunctionExists

### DIFF
--- a/demo/functions/functions-app/package.json
+++ b/demo/functions/functions-app/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@5qtrs/request": "^0.0.1",
     "@types/cookie-parser": "^1.4.1",
+    "@types/dotenv": "^6.1.1",
     "@types/express": "^4.16.1",
     "@types/http-errors": "^1.6.1",
     "@types/morgan": "^1.7.35"

--- a/demo/functions/functions-app/views/playground.ejs
+++ b/demo/functions/functions-app/views/playground.ejs
@@ -39,7 +39,7 @@
       .createEditor(
         document.getElementById('editor'),
         'myboundary',
-        'myfunction18',
+        'myfunction19',
         {
           accountId: 'acc-b503fb00e15248c6',
           subscriptionId: 'sub-b503fb00e15248c6-0000',
@@ -49,7 +49,7 @@
         {
           template: {},
           editor: {
-            // theme: 'dark',
+            theme: 'dark',
             // theme: 'light', // (default)
           },
         }

--- a/lib/client/fusebit-editor/package.json
+++ b/lib/client/fusebit-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/fusebit-editor",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "",
   "main": "libm/index.js",
   "browser": "libm/index.js",

--- a/lib/client/fusebit-editor/src/Options.ts
+++ b/lib/client/fusebit-editor/src/Options.ts
@@ -27,6 +27,13 @@
  */
 export interface IEditorOptions {
   /**
+   * Ensures that the function exists when the editor opens. When set to true, either an existing function
+   * is loaded, or a new function is created from the provided template before the editor opens. When set
+   * to false (default) and the function does not yet exist, the editor opens showing the provided template,
+   * but the user must explicitly save the function for it to be created.
+   */
+  ensureFunctionExists?: boolean;
+  /**
    * Editor style theme.
    */
   theme?: EditorTheme;
@@ -65,6 +72,7 @@ enum EditorTheme {
  * Default values for the [[IEditorPanel]].
  */
 export class EditorOptions implements IEditorOptions {
+  public ensureFunctionExists = false;
   public theme = EditorTheme.Light;
   public actionPanel = new ActionPanelOptions();
   public editorPanel = new EditorPanelOptions();

--- a/yarn.lock
+++ b/yarn.lock
@@ -413,6 +413,13 @@
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.4.tgz#56eec47706f0fd0b7c694eae2f3172e6b0b769da"
   integrity sha512-D9MyoQFI7iP5VdpEyPZyjjqIJ8Y8EDNQFIFVLOmeg1rI1xiHOChyUPMPRUVfqFCerxfE+yS3vMyj37F6IdtOoQ==
 
+"@types/dotenv@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@types/dotenv/-/dotenv-6.1.1.tgz#f7ce1cc4fe34f0a4373ba99fefa437b0bec54b46"
+  integrity sha512-ftQl3DtBvqHl9L16tpqqzA4YzCSXZfi7g8cQceTz5rOlYtk/IZbFjAv3mLOQlNIgOaylCQWQoBdDQHPgEBJPHg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/duplexify@^3.5.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@types/duplexify/-/duplexify-3.6.0.tgz#dfc82b64bd3a2168f5bd26444af165bf0237dcd8"


### PR DESCRIPTION
By default when editor opens but function does not exist, it is opened pre-populated with a template but the user must explicitly save to create the function. EditorContext will be initially in dirty state in this case. 