### PR TITLE
Updates to api.yaml; test improvements; no more 404 with account ids

### DIFF
--- a/api/function-api/api.yaml
+++ b/api/function-api/api.yaml
@@ -47,14 +47,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Account'
-        403:
-          description: Not authorized
+        400: 
+          description: Malformed account id
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        404:
-          description: Account not found
+        403:
+          description: Not authorized
           content:
             application/json:
               schema:
@@ -77,17 +77,19 @@ paths:
       operationId: getAccountSubscriptionList
       description: |
         Returns a list of the subscriptions of the given account.
+
+        Use query string parameters to filter the list of subscriptions. All query filters are combined with a logical AND operator.
       parameters:
         - in: query
           name: next
           required: false
-          description: Optional subscription id to start returning results from
+          description: Optional opaque token to start returning results from
           schema:
-            $ref: '#/components/schemas/SubscriptionId'
+            type: string
         - in: query
           name: count
           required: false
-          description: Optional number of results to return; max is 100
+          description: Optional number of results to return
           schema:
             type: number
             minimum: 1
@@ -99,14 +101,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SubscriptionList'
-        403:
-          description: Not authorized
+        400: 
+          description: Malformed account id or invalid query
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        404:
-          description: Account not found
+        403:
+          description: Not authorized
           content:
             application/json:
               schema:
@@ -148,8 +150,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        400: 
+          description: Malformed account or subscription id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         404:
-          description: Account or subscription not found
+          description: Subscription not found
           content:
             application/json:
               schema:
@@ -192,13 +200,35 @@ paths:
       - in: query
         name: from
         required: false
-        description: Optional time from which to return audit entries; can be any format accepted by Date, or a relative time frame like '-15m', '-24h' etc.
+        description: |
+        Optional time from which to return audit entries. Can be any format accepted by the JavaScript Date constructor
+        or a relative date of the format '-{integer}{s|m|h|d}', where 's' is seconds, 'm' is minutes, 'h' is hours and 'd' is days.
+        
+        All of the following are valid:
+          - from=1559605282105 (absolute time in milliseconds since 1 January 1970 UTC)
+          - from=2019-06-03T23:42:16.976Z
+          - from=Mon, 03 Jun 2019 23:42:30 GMT
+          - from=-30s (30 seconds prior to now)
+          - from=-5m (5 minutes prior to now)
+          - from=-2h (2 hours prior to now)
+          - from=-1d (1 day prior to now)
         schema:
           type: string
       - in: query
         name: to
         required: false
-        description: Optional time up to which to return audit entries; can be any format accepted by Date, or a relative time frame like '-15m', '-24h' etc.
+        description: |
+        Optional time up to which to return audit entries. Can be any format accepted by the JavaScript Date constructor 
+        or a relative date of the format '-{integer}{s|m|h|d}', where 's' is seconds, 'm' is minutes, 'h' is hours and 'd' is days.
+        
+        All of the following are valid:
+          - from=1559605282105 (absolute time in milliseconds since 1 January 1970 UTC)
+          - from=2019-06-03T23:42:16.976Z
+          - from=Mon, 03 Jun 2019 23:42:30 GMT
+          - from=-30s (30 seconds prior to now)
+          - from=-5m (5 minutes prior to now)
+          - from=-2h (2 hours prior to now)
+          - from=-1d (1 day prior to now)
         schema:
           type: string
       - in: query
@@ -224,6 +254,7 @@ paths:
         Returns the audit trail of calls to the HTTP APIs related to resources that belong to the accountId. 
         Each entry of the audit trail contains the timestamp of the call, resource, action, and the identity of 
         the caller represented as the (issuer, subject) pair. Use query string parameters to filter the entries. 
+        All query filters are combined with a logical AND operator.
         
         By default, only the most recent 15 minutes of audit logs are returned. You can change this with the 'from' query parameter.
       responses:
@@ -234,19 +265,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/AccountAudit'
         400:
-          description: Invalid query
+          description: Malformed account id or invalid query
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         403:
           description: Not authorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        404:
-          description: Account not found
           content:
             application/json:
               schema:
@@ -269,6 +294,8 @@ paths:
       operationId: getAccountIssuerList
       description: |
         Returns a list of issuers associated with the given account.
+
+        Use query string parameters to filter the list of issuers. All query filters are combined with a logical AND operator.
       parameters:
         - in: query
           name: name
@@ -297,14 +324,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IssuerList'
-        403:
-          description: Not authorized
+        400:
+          description: Malformed account id or invalid query
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        404:
-          description: Account not found
+        403:
+          description: Not authorized
           content:
             application/json:
               schema:
@@ -340,6 +367,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Issuer'
+        400: 
+          description: Malformed account or issuer id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         403:
           description: Not authorized
           content:
@@ -347,7 +380,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         404:
-          description: Account or issuer not found
+          description: Issuer not found
           content:
             application/json:
               schema:
@@ -376,19 +409,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/Issuer'
         400:
-          description: Invalid issuer
+          description: Malformed account id, invalid issuer or issuer already exists
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         403:
           description: Not authorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        404:
-          description: Account not found
           content:
             application/json:
               schema:
@@ -417,7 +444,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Issuer'
         400:
-          description: Invalid issuer
+          description: Malformed account or issuer id, or invalid issuer
           content:
             application/json:
               schema:
@@ -429,7 +456,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         404:
-          description: Account or issuer not found
+          description: Issuer not found
           content:
             application/json:
               schema:
@@ -446,6 +473,12 @@ paths:
       responses:
         204:
           description: Issuer was deleted
+        400: 
+          description: Malformed account or issuer id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         403:
           description: Not authorized
           content:
@@ -453,7 +486,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         404:
-          description: Account or issuer not found
+          description: Issuer not found
           content:
             application/json:
               schema:
@@ -475,7 +508,9 @@ paths:
       summary: Get clients of an account
       operationId: getAccountClientList
       description: |
-        Returns a list of clients associated with the given account.
+        Returns a list of clients associated with the given account. 
+
+        Use query string parameters to filter the list of clients. All query filters are combined with a logical AND operator.
       parameters:
         - in: query
           name: include
@@ -500,13 +535,13 @@ paths:
         - in: query
           name: issuerId
           required: false
-          description: Optional iss identifier to match against the identities of the clients (case-sensitive)
+          description: Optional issuerId identifier to match against the identities of the clients (case-sensitive)
           schema:
             $ref: '#/components/schemas/IssuerId'
         - in: query
           name: subject
           required: false
-          description: Optional sub identifier to match against the identities of the clients (case-sensitive)
+          description: Optional subject identifier to match against the identities of the clients (case-sensitive)
           schema:
             type: string
         - in: query
@@ -531,11 +566,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/ClientList'
         400:
-          description: Invalid query
+          description: Malformed account id or invalid query
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         403:
           description: Not authorized
-        404:
-          description: Account not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
       security:
         - AccessToken: []
     post:
@@ -560,19 +602,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/Client'
         400:
-          description: Invalid client
+          description: Malformed account id or invalid client
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         403:
           description: Not authorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        404:
-          description: Account not found
           content:
             application/json:
               schema:
@@ -608,6 +644,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Client'
+        400: 
+          description: Malformed account or client id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         403:
           description: Not authorized
           content:
@@ -615,7 +657,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         404:
-          description: Account or client not found
+          description: Client not found
           content:
             application/json:
               schema:
@@ -644,7 +686,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Client'
         400:
-          description: Invalid client
+          description: Malformed account or client id, or invalid client
           content:
             application/json:
               schema:
@@ -656,7 +698,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         404:
-          description: Account or client not found
+          description: Client not found
           content:
             application/json:
               schema:
@@ -673,6 +715,12 @@ paths:
       responses:
         204:
           description: Client was deleted
+        400: 
+          description: Malformed account or client id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         403:
           description: Not authorized
           content:
@@ -680,7 +728,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         404:
-          description: Account or client not found
+          description: Client not found
           content:
             application/json:
               schema:
@@ -702,7 +750,9 @@ paths:
       summary: Get users
       operationId: getUserList
       description: |
-        Returns a list of users.
+        Returns a list of users associated with the given account.
+
+        Use query string parameters to filter the list of users. All query filters are combined with a logical AND operator.
       parameters:
         - in: query
           name: include
@@ -764,19 +814,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/UserList'
         400:
-          description: Invalid query
+          description: Malformed account id or invalid query
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         403:
           description: Not authorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        404:
-          description: Account not found
           content:
             application/json:
               schema:
@@ -805,19 +849,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/User'
         400:
-          description: Invalid user
+          description: Malformed account id or invalid user
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         403:
           description: Not authorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        404:
-          description: Account not found
           content:
             application/json:
               schema:
@@ -854,7 +892,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/User'
         400:
-          description: Invalid userId
+          description: Malformed account or user id
           content:
             application/json:
               schema:
@@ -866,7 +904,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         404:
-          description: Account or user not found
+          description: User not found
           content:
             application/json:
               schema:
@@ -895,7 +933,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/User'
         400:
-          description: Invalid user or userId
+          description: Malformed account or user id, or invalid user
           content:
             application/json:
               schema:
@@ -907,7 +945,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         404:
-          description: Account or user not found
+          description: User not found
           content:
             application/json:
               schema:
@@ -918,13 +956,6 @@ paths:
       tags:
         - Users
       summary: Delete a User
-      parameters:
-        - in: query
-          name: accountId
-          required: false
-          description: Account id from which to remove the user
-          schema:
-            $ref: '#/components/schemas/AccountId'
       description: |
         Removes the user and all of their access and identities
       operationId: deleteUser
@@ -932,7 +963,7 @@ paths:
         204:
           description: User was deleted
         400:
-          description: Invalid userId
+          description: Malformed account or user id
           content:
             application/json:
               schema:
@@ -944,7 +975,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         404:
-          description: Account or user not found
+          description: User not found
           content:
             application/json:
               schema:
@@ -972,6 +1003,8 @@ paths:
       summary: Get the functions of a subscription
       description: |
         Returns the list of functions of a given subscription.
+
+        Use query string parameters to filter the list of functions. All query filters are combined with a logical AND operator.
       operationId: getSubscriptionFunctionList
       parameters:
         - in: query
@@ -979,11 +1012,11 @@ paths:
           required: false
           description: Optional opaque token to start returning results from
           schema:
-            $ref: '#/components/schemas/FunctionId'
+            type: string
         - in: query
           name: count
           required: false
-          description: Optional number of results to return; max is 100
+          description: Optional number of results to return
           schema:
             type: number
             minimum: 1
@@ -1001,6 +1034,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FunctionList'
+        400: 
+          description: Malformed account or subscription id, or invalid query
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         403:
           description: Not authorized
           content:
@@ -1008,7 +1047,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         404:
-          description: Account or subscription not found
+          description: Subscription not found
           content:
             application/json:
               schema:
@@ -1042,6 +1081,8 @@ paths:
       summary: Get the functions of a boundary
       description: |
         Returns the list of functions in a given boundary of a given subscription.
+
+        Use query string parameters to filter the list of functions. All query filters are combined with a logical AND operator.
       operationId: getFunctionList
       parameters:
         - in: query
@@ -1049,11 +1090,11 @@ paths:
           required: false
           description: Optional opaque token to start returning results from
           schema:
-            $ref: '#/components/schemas/FunctionId'
+            type: string
         - in: query
           name: count
           required: false
-          description: Optional number of results to return; max is 100
+          description: Optional number of results to return
           schema:
             type: number
             minimum: 1
@@ -1071,6 +1112,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FunctionList'
+        400: 
+          description: Malformed account or subscription id, or invalid query
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         403:
           description: Not authorized
           content:
@@ -1078,7 +1125,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         404:
-          description: Account, subscription or boundary not found
+          description: Subscription or boundary not found
           content:
             application/json:
               schema:
@@ -1116,6 +1163,12 @@ paths:
       responses:
         200:
           description: Stream of text/event-stream log data
+        400: 
+          description: Malformed account, subscription or boundary id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         403:
           description: Not authorized
           content:
@@ -1123,7 +1176,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         404:
-          description: Account, subscription or boundary not found
+          description: Subscription or boundary not found
           content:
             application/json:
               schema:
@@ -1171,6 +1224,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Function'
+        400: 
+          description: Malformed account, subscription, boundary or function id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         403:
           description: Not authorized
           content:
@@ -1178,7 +1237,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         404:
-          description: Account, subscription, boundary or function not found
+          description: Subscription, boundary or function not found
           content:
             application/json:
               schema:
@@ -1216,8 +1275,8 @@ paths:
                 $ref: '#/components/schemas/Build'
         204:
           description: No change to function
-        400:
-          description: Invalid function
+        400: 
+          description: Malformed account, subscription, boundary or function id, or invalid function
           content:
             application/json:
               schema:
@@ -1229,7 +1288,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         404:
-          description: Account, subscription, boundary or function not found
+          description: Subscription, boundary or function not found
           content:
             application/json:
               schema:
@@ -1253,6 +1312,12 @@ paths:
       responses:
         204:
           description: Function was deleted
+        400: 
+          description: Malformed account, subscription, boundary or function id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         403:
           description: Not authorized
           content:
@@ -1304,6 +1369,12 @@ paths:
       responses:
         200:
           description: Stream of text/event-stream log data
+        400: 
+          description: Malformed account, subscription, boundary or function id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         403:
           description: Not authorized
           content:
@@ -1311,7 +1382,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         404:
-          description: Subscription, boundary of function not found
+          description: Subscription, boundary or function not found
           content:
             application/json:
               schema:
@@ -1359,6 +1430,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FunctionLocation'
+        400: 
+          description: Malformed account, subscription, boundary or function id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         403:
           description: Not authorized
           content:
@@ -1366,7 +1443,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         404:
-          description: Account, subscription, boundary of function not found
+          description: Subscription, boundary or function not found
           content:
             application/json:
               schema:
@@ -1426,8 +1503,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Build'
-        400:
-          description: Invalid function
+        400: 
+          description: Malformed account, subscription, boundary, function or build id, or invalid function
           content:
             application/json:
               schema:
@@ -1439,7 +1516,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         404:
-          description: Account, subscription, boundary or function not found
+          description: Subscription, boundary or function not found
           content:
             application/json:
               schema:
@@ -1479,12 +1556,12 @@ components:
         message:
           type: string
           description: A message with details regarding the error
-          example: The user 'usr-12345' does not exist
+          example: The user 'usr-5555555555555555' does not exist
 
     AccountId:
       type: string
       description: Account id
-      example: 'acc-02387f60baea4887a24669ef70705173'
+      example: 'acc-5555555555555555'
 
     Account:
       type: object
@@ -1509,7 +1586,7 @@ components:
       properties:
         next:
           type: string
-          description: Opaque token to continue listing from
+          description: Opaque token to continue getting results from
         items:
           type: array
           items:
@@ -1524,6 +1601,7 @@ components:
         - accountId
         - issuerId
         - subject
+        - authorized
       properties:
         accountId:
           $ref: '#/components/schemas/AccountId'
@@ -1538,7 +1616,7 @@ components:
         resource:
           type: string
           description: Name of the resource on which the action was performed
-          example: /account/acc-abcde/subscription/sub-12345/boundary/myboundary/function/myfunction17
+          example: /account/acc-5555555555555555/subscription/sub-5555555555555555/boundary/boundary-1/function/function-17
         issuerId:
           type: string
           description: Identifier of the issuer that authenticated the user
@@ -1547,11 +1625,14 @@ components:
           type: string
           description: Identifier of the user, unique within the issuer
           example: google-oauth2|skjdhfsadhfalkajsdhf
+        authorized:
+            type: boolean
+            description: If 'true' the action was authorized; if 'false' the action was not authorized and was not allowed to continue
 
     SubscriptionId:
       type: string
       description: Subscription id
-      example: 'sub-387669ef70700237a24517f60baea488'
+      example: 'sub-5555555555555555'
 
     Subscription:
       type: object
@@ -1572,7 +1653,7 @@ components:
       properties:
         next:
           type: string
-          description: Opaque token to continue listing from
+          description: Opaque token to continue getting results from
         items:
           type: array
           description: A list of subscriptions
@@ -1634,7 +1715,7 @@ components:
       properties:
         next:
           type: string
-          description: Opaque token to continue listing from
+          description: Opaque token to continue getting results from
         items:
           type: array
           description: A list of issuers
@@ -1662,14 +1743,17 @@ components:
         action:
           type: string
           description: The action to perform
+          example: function:*
         resource:
           type: string
           description: The resource to perform the action on
+          example: /account/acc-5555555555555555/subscription/sub-5555555555555555/boundary/my-boundary-1/function/my-function-17
 
     ClientId:
       type: string
       description: Client id
-      example: 'clt-cc46f3ab0760a9f411b72096e65cd1cc'
+      example: 'clt-5555555555555555'
+    
     NewClient:
       type: object
       properties:
@@ -1697,6 +1781,7 @@ components:
             id:
               $ref: '#/components/schemas/ClientId'
         - $ref: '#/components/schemas/NewClient'
+    
     ClientList:
       type: object
       required:
@@ -1704,7 +1789,7 @@ components:
       properties:
         next:
           type: string
-          description: Opaque token to continue listing from
+          description: Opaque token to continue getting results from
         items:
           type: array
           description: A list of clients
@@ -1714,7 +1799,8 @@ components:
     UserId:
       type: string
       description: User id
-      example: 'usr-9f411b7209cc46f3ab0760a6e65cd1cc'
+      example: 'usr-5555555555555555'
+
     NewUser:
       type: object
       properties:
@@ -1750,6 +1836,7 @@ components:
             id:
               $ref: '#/components/schemas/UserId'
         - $ref: '#/components/schemas/NewUser'
+    
     UserList:
       type: object
       required:
@@ -1757,7 +1844,7 @@ components:
       properties:
         next:
           type: string
-          description: Opaque token to continue listing from
+          description: Opaque token to continue getting results from
         items:
           type: array
           description: A list of users
@@ -1767,12 +1854,12 @@ components:
     BoundaryId:
       type: string
       description: Boundary id
-      example: 'tenant-xyz'
+      example: my-boundary-xyz
 
     FunctionId:
       type: string
       description: Function id
-      example: 'task-123'
+      example: my-function-abc
 
     FunctionLocation:
       type: object
@@ -1782,7 +1869,7 @@ components:
         location:
           type: string
           description: The URL for executing the function
-          example: 'https://domain.com/task-abc'
+          example: 'https://domain.com/function-abc'
 
     FunctionShort:
       type: object
@@ -1878,7 +1965,8 @@ components:
         - items
       properties:
         next:
-          $ref: '#/components/schemas/FunctionId'
+          type: string
+          description: Opaque token to continue getting results from
         items:
           type: array
           description: A list of functions
@@ -1888,7 +1976,7 @@ components:
     BuildId:
       type: string
       description: Build id
-      example: 'bld-9f411b7209cc46f3ab0760a6e65cd1cc'
+      example: sb9oa2
 
     Build:
       allOf:

--- a/api/function-api/src/routes/account.js
+++ b/api/function-api/src/routes/account.js
@@ -5,6 +5,8 @@ const { AccountDataAwsContextFactory } = require('@5qtrs/account-data-aws');
 
 let accountContext;
 
+const unauthorizedErrorCodes = ['unauthorized', 'invalidJwt', 'noPublicKey', 'unresolvedAgent'];
+
 async function getAccountContext() {
   if (!accountContext) {
     const config = new Config({
@@ -47,7 +49,7 @@ function errorHandler(res) {
     let message = 'An unknown error occured on the server';
     let log = true;
 
-    if (error.code === 'unauthorized' || error.code === 'invalidJwt' || error.code === 'noPublicKey') {
+    if (unauthorizedErrorCodes.indexOf(error.code) !== -1) {
       status = 403;
       message = 'Unauthorized';
       log = false;

--- a/api/function-api/src/routes/schemas/api_account.js
+++ b/api/function-api/src/routes/schemas/api_account.js
@@ -1,0 +1,7 @@
+const Joi = require('joi');
+
+module.exports = Joi.object()
+  .options({ allowUnknown: true })
+  .keys({
+    accountId: Joi.string().regex(/^acc-[a-g0-9]{16}$/),
+  });

--- a/api/function-api/src/routes/schemas/api_params.js
+++ b/api/function-api/src/routes/schemas/api_params.js
@@ -1,12 +1,12 @@
 const Joi = require('joi');
 
 module.exports = Joi.object().keys({
-  issuerId: Joi.string(),
   accountId: Joi.string().regex(/^acc-[a-g0-9]{16}$/),
+  issuerId: Joi.string(),
   clientId: Joi.string().regex(/^clt-[a-g0-9]{16}$/),
   userId: Joi.string().regex(/^usr-[a-g0-9]{16}$/),
   initId: Joi.string().regex(/^int-[a-g0-9]{16}$/),
-  subscriptionId: Joi.string().regex(/^sub-[a-g0-9]{16}(?:-[a-g0-9]{4})?$/),
+  subscriptionId: Joi.string().regex(/^sub-[a-g0-9]{16}$/),
   boundaryId: Joi.string().regex(/^[a-z0-9\-]{1,63}$/),
   functionId: Joi.string().regex(/^[a-z0-9\-]{1,64}$/),
   buildId: Joi.string(),

--- a/api/function-api/src/routes/v1_api.js
+++ b/api/function-api/src/routes/v1_api.js
@@ -55,6 +55,7 @@ router.options('/account', cors(corsManagementOptions));
 router.post(
   '/account',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.addAccount }),
   express.json(),
   validate_schema({
@@ -67,6 +68,7 @@ router.options('/account/:accountId', cors(corsManagementOptions));
 router.get(
   '/account/:accountId',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.getAccount }),
   validate_schema({
     params: require('./schemas/api_params'),
@@ -78,6 +80,7 @@ router.options('/account/:accountId/audit', cors(corsManagementOptions));
 router.get(
   '/account/:accountId/audit',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.getAudit }),
   validate_schema({
     query: require('./schemas/api_query'),
@@ -92,6 +95,7 @@ router.options('/account/:accountId/issuer', cors(corsManagementOptions));
 router.get(
   '/account/:accountId/issuer',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.getIssuer }),
   validate_schema({
     query: require('./schemas/api_query'),
@@ -104,6 +108,7 @@ router.options('/account/:accountId/issuer/:issuerId', cors(corsManagementOption
 router.get(
   '/account/:accountId/issuer/:issuerId',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.getIssuer }),
   validate_schema({
     params: require('./schemas/api_params'),
@@ -114,6 +119,7 @@ router.get(
 router.post(
   '/account/:accountId/issuer/:issuerId',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.addIssuer }),
   express.json(),
   validate_schema({
@@ -125,6 +131,7 @@ router.post(
 router.patch(
   '/account/:accountId/issuer/:issuerId',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.updateIssuer }),
   express.json(),
   validate_schema({
@@ -136,6 +143,7 @@ router.patch(
 router.delete(
   '/account/:accountId/issuer/:issuerId',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.deleteIssuer }),
   validate_schema({
     params: require('./schemas/api_params'),
@@ -149,6 +157,7 @@ router.options('/account/:accountId/subscription', cors(corsManagementOptions));
 router.post(
   '/account/:accountId/subscription',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.addSubscription }),
   express.json(),
   validate_schema({
@@ -162,6 +171,7 @@ router.options('/account/:accountId/subscription', cors(corsManagementOptions));
 router.get(
   '/account/:accountId/subscription',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.getSubscription }),
   validate_schema({
     query: require('./schemas/api_query'),
@@ -174,6 +184,7 @@ router.options('/account/:accountId/subscription/:subscriptionId', cors(corsMana
 router.get(
   '/account/:accountId/subscription/:subscriptionId',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.getSubscription }),
   validate_schema({
     params: require('./schemas/api_params'),
@@ -187,6 +198,7 @@ router.options('/account/:accountId/user', cors(corsManagementOptions));
 router.get(
   '/account/:accountId/user',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.getUser }),
   validate_schema({
     query: require('./schemas/api_query'),
@@ -198,6 +210,7 @@ router.get(
 router.post(
   '/account/:accountId/user',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.addUser }),
   express.json(),
   validate_schema({
@@ -211,6 +224,7 @@ router.options('/account/:accountId/user/:userId', cors(corsManagementOptions));
 router.get(
   '/account/:accountId/user/:userId',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.getUser }),
   validate_schema({
     params: require('./schemas/api_params'),
@@ -221,6 +235,7 @@ router.get(
 router.patch(
   '/account/:accountId/user/:userId',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.updateUser }),
   express.json(),
   validate_schema({
@@ -233,6 +248,7 @@ router.patch(
 router.delete(
   '/account/:accountId/user/:userId',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.deleteUser }),
   validate_schema({
     params: require('./schemas/api_params'),
@@ -243,6 +259,7 @@ router.delete(
 router.post(
   '/account/:accountId/user/:userId/init',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.initUser }),
   express.json(),
   validate_schema({
@@ -255,6 +272,7 @@ router.post(
 router.post(
   '/account/:accountId/init',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ resolve: true }),
   express.json(),
   validate_schema({
@@ -270,6 +288,7 @@ router.options('/account/:accountId/client', cors(corsManagementOptions));
 router.get(
   '/account/:accountId/client',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.getClient }),
   validate_schema({
     query: require('./schemas/api_query'),
@@ -280,6 +299,7 @@ router.get(
 router.post(
   '/account/:accountId/client',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.addClient }),
   express.json(),
   validate_schema({
@@ -293,6 +313,7 @@ router.options('/account/:accountId/client/:clientId', cors(corsManagementOption
 router.get(
   '/account/:accountId/client/:clientId',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.getClient }),
   validate_schema({
     params: require('./schemas/api_params'),
@@ -302,6 +323,7 @@ router.get(
 router.patch(
   '/account/:accountId/client/:clientId',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.updateClient }),
   express.json(),
   validate_schema({
@@ -313,6 +335,7 @@ router.patch(
 router.delete(
   '/account/:accountId/client/:clientId',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.deleteClient }),
   validate_schema({
     params: require('./schemas/api_params'),
@@ -323,6 +346,7 @@ router.delete(
 router.post(
   '/account/:accountId/client/:clientId/init',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({ operation: AccountActions.initClient }),
   express.json(),
   validate_schema({
@@ -341,6 +365,7 @@ router.options(
 router.get(
   '/account/:accountId/subscription/:subscriptionId/boundary/:boundaryId/function',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({
     operation: 'function:list',
   }),
@@ -359,6 +384,7 @@ router.options(
 router.get(
   '/account/:accountId/subscription/:subscriptionId/boundary/:boundaryId/log',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({
     operation: 'function:get-log',
     getToken: req => req.query && req.query.token,
@@ -376,6 +402,7 @@ router.options('/account/:accountId/subscription/:subscriptionId/function', cors
 router.get(
   '/account/:accountId/subscription/:subscriptionId/function',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({
     operation: 'function:list',
   }),
@@ -394,6 +421,7 @@ router.options(
 router.get(
   '/account/:accountId/subscription/:subscriptionId/boundary/:boundaryId/function/:functionId',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({
     operation: 'function:get',
   }),
@@ -406,6 +434,7 @@ router.get(
 router.put(
   '/account/:accountId/subscription/:subscriptionId/boundary/:boundaryId/function/:functionId',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({
     operation: 'function:put',
   }),
@@ -420,6 +449,7 @@ router.put(
 router.delete(
   '/account/:accountId/subscription/:subscriptionId/boundary/:boundaryId/function/:functionId',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({
     operation: 'function:delete',
   }),
@@ -437,6 +467,7 @@ router.options(
 router.get(
   '/account/:accountId/subscription/:subscriptionId/boundary/:boundaryId/function/:functionId/log',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({
     operation: 'function:get-log',
     getToken: req => req.query && req.query.token,
@@ -455,6 +486,7 @@ router.options(
 router.get(
   '/account/:accountId/subscription/:subscriptionId/boundary/:boundaryId/function/:functionId/location',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({
     operation: 'function:get-location',
   }),
@@ -472,6 +504,7 @@ router.options(
 router.get(
   '/account/:accountId/subscription/:subscriptionId/boundary/:boundaryId/function/:functionId/build/:buildId',
   cors(corsManagementOptions),
+  validate_schema({ params: require('./schemas/api_account') }),
   authorize({
     operation: 'function:get-build',
   }),

--- a/api/function-api/test/accountResolver.ts
+++ b/api/function-api/test/accountResolver.ts
@@ -23,6 +23,26 @@ export function cloneWithAccessToken(account: IAccount, accessToken: string) {
   };
 }
 
+export async function getMalformedAccount(): Promise<IAccount> {
+  const account = await resolveAccount();
+  return {
+    accountId: 'acc-1234',
+    subscriptionId: account.subscriptionId,
+    baseUrl: account.baseUrl,
+    accessToken: account.accessToken,
+  };
+}
+
+export async function getNonExistingAccount(): Promise<IAccount> {
+  const account = await resolveAccount();
+  return {
+    accountId: 'acc-9999999999999999',
+    subscriptionId: account.subscriptionId,
+    baseUrl: account.baseUrl,
+    accessToken: account.accessToken,
+  };
+}
+
 export async function resolveAccount(): Promise<IAccount> {
   if (process.env.API_SERVER && process.env.API_AUTHORIZATION_KEY) {
     return {

--- a/api/function-api/test/client.add.test.ts
+++ b/api/function-api/test/client.add.test.ts
@@ -1,18 +1,14 @@
-import { IAccount, FakeAccount, resolveAccount } from './accountResolver';
+import { IAccount, FakeAccount, resolveAccount, getMalformedAccount, getNonExistingAccount } from './accountResolver';
 import { addClient, addUser, cleanUpClients } from './sdk';
 import { random } from '@5qtrs/random';
+import { extendExpect } from './extendJest';
+
+const expectMore = extendExpect(expect);
 
 let account: IAccount = FakeAccount;
-let invalidAccount: IAccount = FakeAccount;
 
 beforeAll(async () => {
   account = await resolveAccount();
-  invalidAccount = {
-    accountId: 'acc-9999999999999999',
-    subscriptionId: account.subscriptionId,
-    baseUrl: account.baseUrl,
-    accessToken: account.accessToken,
-  };
 });
 
 afterEach(async () => {
@@ -89,10 +85,7 @@ describe('Client', () => {
 
     test('Adding a client with an empty string display name is not supported', async () => {
       const client = await addClient(account, { displayName: '' });
-      expect(client.status).toBe(400);
-      expect(client.data.status).toBe(400);
-      expect(client.data.statusCode).toBe(400);
-      expect(client.data.message).toBe('"displayName" is not allowed to be empty');
+      expectMore(client).toBeHttpError(400, '"displayName" is not allowed to be empty');
     }, 20000);
 
     test('Adding a client with an exisitng identity returns an error', async () => {
@@ -100,10 +93,8 @@ describe('Client', () => {
       const identities = [{ issuerId: 'test', subject }];
       await addClient(account, { identities });
       const client = await addClient(account, { identities });
-      expect(client.status).toBe(400);
-      expect(client.data.status).toBe(400);
-      expect(client.data.statusCode).toBe(400);
-      expect(client.data.message).toBe(
+      expectMore(client).toBeHttpError(
+        400,
         `The identity with issuer 'test' and subject '${subject}' is already associated with a user or client`
       );
     }, 20000);
@@ -113,10 +104,8 @@ describe('Client', () => {
       const identities = [{ issuerId: 'test', subject }];
       await addUser(account, { identities });
       const client = await addClient(account, { identities });
-      expect(client.status).toBe(400);
-      expect(client.data.status).toBe(400);
-      expect(client.data.statusCode).toBe(400);
-      expect(client.data.message).toBe(
+      expectMore(client).toBeHttpError(
+        400,
         `The identity with issuer 'test' and subject '${subject}' is already associated with a user or client`
       );
     }, 20000);
@@ -124,110 +113,78 @@ describe('Client', () => {
     test('Adding a client with an identity with an empty issuerId is not supported', async () => {
       const identities = [{ issuerId: '', subject: `sub-${random()}` }];
       const client = await addClient(account, { identities });
-      expect(client.status).toBe(400);
-      expect(client.data.status).toBe(400);
-      expect(client.data.statusCode).toBe(400);
-      expect(client.data.message).toBe('"issuerId" is not allowed to be empty');
+      expectMore(client).toBeHttpError(400, '"issuerId" is not allowed to be empty');
     }, 20000);
 
     test('Adding a client with an identity with a missing issuerId is not supported', async () => {
       const identities = [{ subject: `sub-${random()}` }];
       const client = await addClient(account, { identities });
-      expect(client.status).toBe(400);
-      expect(client.data.status).toBe(400);
-      expect(client.data.statusCode).toBe(400);
-      expect(client.data.message).toBe('"issuerId" is required');
+      expectMore(client).toBeHttpError(400, '"issuerId" is required');
     }, 20000);
 
     test('Adding a client with an identity with an empty subject is not supported', async () => {
       const identities = [{ issuerId: 'foo', subject: '' }];
       const client = await addClient(account, { identities });
-      expect(client.status).toBe(400);
-      expect(client.data.status).toBe(400);
-      expect(client.data.statusCode).toBe(400);
-      expect(client.data.message).toBe('"subject" is not allowed to be empty');
+      expectMore(client).toBeHttpError(400, '"subject" is not allowed to be empty');
     }, 20000);
 
     test('Adding a client with an identity with a missing subject is not supported', async () => {
       const identities = [{ issuerId: 'foo' }];
       const client = await addClient(account, { identities });
-      expect(client.status).toBe(400);
-      expect(client.data.status).toBe(400);
-      expect(client.data.statusCode).toBe(400);
-      expect(client.data.message).toBe('"subject" is required');
+      expectMore(client).toBeHttpError(400, '"subject" is required');
     }, 20000);
 
     test('Adding a client with access with an empty action is not supported', async () => {
       const access = { allow: [{ action: '', resource: '/' }] };
       const client = await addClient(account, { access });
-      expect(client.status).toBe(400);
-      expect(client.data.status).toBe(400);
-      expect(client.data.statusCode).toBe(400);
-      expect(client.data.message).toBe('"action" is not allowed to be empty');
+      expectMore(client).toBeHttpError(400, '"action" is not allowed to be empty');
     }, 20000);
 
     test('Adding a client with access with a missing action is not supported', async () => {
       const access = { allow: [{ resource: '/' }] };
       const client = await addClient(account, { access });
-      expect(client.status).toBe(400);
-      expect(client.data.status).toBe(400);
-      expect(client.data.statusCode).toBe(400);
-      expect(client.data.message).toBe('"action" is required');
+      expectMore(client).toBeHttpError(400, '"action" is required');
     }, 20000);
 
     test('Adding a client with access with an empty resource is not supported', async () => {
       const access = { allow: [{ action: '*', resource: '' }] };
       const client = await addClient(account, { access });
-      expect(client.status).toBe(400);
-      expect(client.data.status).toBe(400);
-      expect(client.data.statusCode).toBe(400);
-      expect(client.data.message).toBe('"resource" is not allowed to be empty');
+      expectMore(client).toBeHttpError(400, '"resource" is not allowed to be empty');
     }, 20000);
 
     test('Adding a client with access with a missing resource is not supported', async () => {
       const access = { allow: [{ action: '*' }] };
       const client = await addClient(account, { access });
-      expect(client.status).toBe(400);
-      expect(client.data.status).toBe(400);
-      expect(client.data.statusCode).toBe(400);
-      expect(client.data.message).toBe('"resource" is required');
+      expectMore(client).toBeHttpError(400, '"resource" is required');
     }, 20000);
 
     test('Adding a client with access with no allow is not supported', async () => {
       const access = {};
       const client = await addClient(account, { access });
-      expect(client.status).toBe(400);
-      expect(client.data.status).toBe(400);
-      expect(client.data.statusCode).toBe(400);
-      expect(client.data.message).toBe('"allow" is required');
+      expectMore(client).toBeHttpError(400, '"allow" is required');
     }, 20000);
 
     test('Adding a client with access with an empty allow array is not supported', async () => {
       const access = { allow: [] };
       const client = await addClient(account, { access });
-      expect(client.status).toBe(400);
-      expect(client.data.status).toBe(400);
-      expect(client.data.statusCode).toBe(400);
-      expect(client.data.message).toBe('"allow" must contain at least 1 items');
+      expectMore(client).toBeHttpError(400, '"allow" must contain at least 1 items');
     }, 20000);
 
     test('Adding a client with identities with an empty array is not supported', async () => {
       const identities: any = [];
       const client = await addClient(account, { identities });
-      expect(client.status).toBe(400);
-      expect(client.data.status).toBe(400);
-      expect(client.data.statusCode).toBe(400);
-      expect(client.data.message).toBe('"identities" must contain at least 1 items');
+      expectMore(client).toBeHttpError(400, '"identities" must contain at least 1 items');
+    }, 20000);
+
+    test('Adding a client with a malformed account should return an error', async () => {
+      const malformed = await getMalformedAccount();
+      const client = await addClient(malformed, {});
+      expectMore(client).toBeMalformedAccountError(malformed.accountId);
     }, 20000);
 
     test('Adding a client with a non-existing account should return an error', async () => {
-      const client = await addClient(invalidAccount, {});
-      expect(client.status).toBe(404);
-      expect(client.data.status).toBe(404);
-      expect(client.data.statusCode).toBe(404);
-
-      const message = client.data.message.replace(/'[^']*'/, '<issuer>');
-      expect(message).toBe(`The issuer <issuer> is not associated with the account`);
+      const client = await addClient(await getNonExistingAccount(), {});
+      expectMore(client).toBeUnauthorizedError();
     }, 20000);
   });
 });

--- a/api/function-api/test/client.remove.test.ts
+++ b/api/function-api/test/client.remove.test.ts
@@ -1,18 +1,14 @@
-import { IAccount, FakeAccount, resolveAccount } from './accountResolver';
+import { IAccount, FakeAccount, resolveAccount, getMalformedAccount, getNonExistingAccount } from './accountResolver';
 import { addClient, getClient, removeClient, cleanUpClients } from './sdk';
 import { random } from '@5qtrs/random';
+import { extendExpect } from './extendJest';
+
+const expectMore = extendExpect(expect);
 
 let account: IAccount = FakeAccount;
-let invalidAccount: IAccount = FakeAccount;
 
 beforeAll(async () => {
   account = await resolveAccount();
-  invalidAccount = {
-    accountId: 'acc-9999999999999999',
-    subscriptionId: account.subscriptionId,
-    baseUrl: account.baseUrl,
-    accessToken: account.accessToken,
-  };
 });
 
 afterEach(async () => {
@@ -34,16 +30,14 @@ describe('Client', () => {
       expect(client.data).toBeUndefined();
 
       const removed = await getClient(account, original.data.id);
-      expect(removed.status).toBe(404);
+      expectMore(removed).toBeHttpError(404, `The client '${original.data.id}' does not exist`);
     }, 20000);
 
     test('Removing a client with an invalid client id should return an error', async () => {
       const clientId = `clt-${random()}`;
       const client = await removeClient(account, clientId);
-      expect(client.status).toBe(400);
-      expect(client.data.status).toBe(400);
-      expect(client.data.statusCode).toBe(400);
-      expect(client.data.message).toBe(
+      expectMore(client).toBeHttpError(
+        400,
         `"clientId" with value "${clientId}" fails to match the required pattern: /^clt-[a-g0-9]{16}$/`
       );
     }, 20000);
@@ -51,21 +45,20 @@ describe('Client', () => {
     test('Removing a non-existing client should return an error', async () => {
       const clientId = `clt-${random({ lengthInBytes: 8 })}`;
       const client = await removeClient(account, clientId);
-      expect(client.status).toBe(404);
-      expect(client.data.status).toBe(404);
-      expect(client.data.statusCode).toBe(404);
-      expect(client.data.message).toBe(`The client '${clientId}' does not exist`);
+      expectMore(client).toBeHttpError(404, `The client '${clientId}' does not exist`);
     }, 20000);
+
+    test('Removing a client with a malformed account should return an error', async () => {
+      const original = await addClient(account, {});
+      const malformed = await getMalformedAccount();
+      const client = await removeClient(malformed, original.data.id);
+      expectMore(client).toBeMalformedAccountError(malformed.accountId);
+    }, 10000);
 
     test('Removing an client with a non-existing account should return an error', async () => {
       const original = await addClient(account, {});
-      const client = await removeClient(invalidAccount, original.data.id);
-      expect(client.status).toBe(404);
-      expect(client.data.status).toBe(404);
-      expect(client.data.statusCode).toBe(404);
-
-      const message = client.data.message.replace(/'[^']*'/, '<issuer>');
-      expect(message).toBe(`The issuer <issuer> is not associated with the account`);
+      const client = await removeClient(await getNonExistingAccount(), original.data.id);
+      expectMore(client).toBeUnauthorizedError();
     }, 10000);
   });
 });

--- a/api/function-api/test/extendJest.ts
+++ b/api/function-api/test/extendJest.ts
@@ -1,0 +1,78 @@
+import { IHttpResponse } from '@5qtrs/request';
+
+// ------------------
+// Internal Functions
+// ------------------
+
+function toBeHttpError(received: any, status: number, message: string) {
+  let pass = false;
+  let result = `expected HTTP response to be defined`;
+  if (received) {
+    if (!received.status) {
+      result = `expected HTTP response to have a status`;
+    } else if (received.status !== status) {
+      result = `expected HTTP response status '${received.status}' to be '${status}'`;
+    } else {
+      if (!received.data) {
+        result = `expected HTTP response to have data'`;
+      } else {
+        if (!received.data.status) {
+          result = `expected HTTP response data to have a 'status' property`;
+        } else if (received.data.status !== status) {
+          result = `expected HTTP response data status '${received.data.status}' to be '${status}'`;
+        } else {
+          if (!received.data.statusCode) {
+            result = `expected HTTP response data to have a 'statusCode' property`;
+          } else if (received.data.statusCode !== status) {
+            result = `expected HTTP response data status code '${received.data.statusCode}' to be '${status}'`;
+          } else {
+            if (!received.data.message) {
+              result = `expected HTTP response data to have a 'message' property`;
+            } else if (received.data.message !== message) {
+              result = `expected HTTP response data message '${received.data.message}' to be '${message}'`;
+            } else {
+              pass = true;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    message: () => result,
+    pass,
+  };
+}
+
+function toBeMalformedAccountError(received: any, malformedAccountId: string) {
+  const message = [
+    `"accountId" with value "${malformedAccountId}"`,
+    'fails to match the required pattern: /^acc-[a-g0-9]{16}$/',
+  ].join(' ');
+  return toBeHttpError(received, 400, message);
+}
+
+function toBeUnauthorizedError(received: any) {
+  return toBeHttpError(received, 403, 'Unauthorized');
+}
+
+// -------------------
+// Exported Interfaces
+// -------------------
+
+export interface ExtendedMatchers extends jest.Matchers<IHttpResponse> {
+  toBeHttpError: (status: number, message: string) => void;
+  toBeMalformedAccountError: (malformedAccountId: string) => void;
+  toBeUnauthorizedError: () => void;
+}
+
+// ------------------
+// Exported Functions
+// ------------------
+
+export function extendExpect(expect: any): (value: any) => ExtendedMatchers {
+  expect.extend({ toBeHttpError, toBeMalformedAccountError, toBeUnauthorizedError });
+
+  return expect as (value: any) => ExtendedMatchers;
+}

--- a/api/function-api/test/issuer.get.test.ts
+++ b/api/function-api/test/issuer.get.test.ts
@@ -1,18 +1,14 @@
 import { random } from '@5qtrs/random';
-import { IAccount, FakeAccount, resolveAccount } from './accountResolver';
+import { IAccount, FakeAccount, resolveAccount, getMalformedAccount, getNonExistingAccount } from './accountResolver';
 import { addIssuer, getIssuer, cleanUpIssuers } from './sdk';
+import { extendExpect } from './extendJest';
+
+const expectMore = extendExpect(expect);
 
 let account: IAccount = FakeAccount;
-let invalidAccount: IAccount = FakeAccount;
 
 beforeAll(async () => {
   account = await resolveAccount();
-  invalidAccount = {
-    accountId: 'acc-9999999999999999',
-    subscriptionId: account.subscriptionId,
-    baseUrl: account.baseUrl,
-    accessToken: account.accessToken,
-  };
 });
 
 afterEach(async () => {
@@ -48,24 +44,18 @@ describe('Issuer', () => {
     test('Getting a non-existing issuer should return an error', async () => {
       const issuerId = `test-${random()}`;
       const issuer = await getIssuer(account, issuerId);
-      expect(issuer.status).toBe(404);
-      expect(issuer.data.status).toBe(404);
-      expect(issuer.data.statusCode).toBe(404);
-      expect(issuer.data.message).toBe(`The issuer '${issuerId}' is not associated with the account`);
+      expectMore(issuer).toBeHttpError(404, `The issuer '${issuerId}' is not associated with the account`);
+    }, 10000);
+
+    test('Getting an issuer with an malformed account id should return an error', async () => {
+      const malformed = await getMalformedAccount();
+      const issuer = await getIssuer(malformed, `test-${random()}`);
+      expectMore(issuer).toBeMalformedAccountError(malformed.accountId);
     }, 10000);
 
     test('Getting an issuer with a non-existing account should return an error', async () => {
-      const issuerId = `test-${random()}`;
-      const publicKeys = [{ publicKey: 'bar', keyId: 'kid-0' }];
-      await addIssuer(account, issuerId, { publicKeys, displayName: 'fuzz' });
-
-      const issuer = await getIssuer(invalidAccount, issuerId);
-      expect(issuer.status).toBe(404);
-      expect(issuer.data.status).toBe(404);
-      expect(issuer.data.statusCode).toBe(404);
-
-      const message = issuer.data.message.replace(/'[^']*'/, '<issuer>');
-      expect(message).toBe(`The issuer <issuer> is not associated with the account`);
+      const issuer = await getIssuer(await getNonExistingAccount(), `test-${random()}`);
+      expectMore(issuer).toBeUnauthorizedError();
     }, 10000);
   });
 });

--- a/api/function-api/test/issuer.remove.test.ts
+++ b/api/function-api/test/issuer.remove.test.ts
@@ -1,18 +1,14 @@
 import { random } from '@5qtrs/random';
-import { IAccount, FakeAccount, resolveAccount } from './accountResolver';
+import { IAccount, FakeAccount, resolveAccount, getMalformedAccount, getNonExistingAccount } from './accountResolver';
 import { addIssuer, getIssuer, removeIssuer, cleanUpIssuers } from './sdk';
+import { extendExpect } from './extendJest';
+
+const expectMore = extendExpect(expect);
 
 let account: IAccount = FakeAccount;
-let invalidAccount: IAccount = FakeAccount;
 
 beforeAll(async () => {
   account = await resolveAccount();
-  invalidAccount = {
-    accountId: 'acc-9999999999999999',
-    subscriptionId: account.subscriptionId,
-    baseUrl: account.baseUrl,
-    accessToken: account.accessToken,
-  };
 });
 
 afterEach(async () => {
@@ -30,16 +26,23 @@ describe('Issuer', () => {
       expect(issuer.data).toBeUndefined();
 
       const removed = await getIssuer(account, issuerId);
-      expect(removed.status).toBe(404);
+      expectMore(removed).toBeHttpError(404, `The issuer '${issuerId}' is not associated with the account`);
     }, 10000);
 
     test('Removing a non-existing issuer should return an error', async () => {
       const issuerId = `test-${random()}`;
       const issuer = await removeIssuer(account, issuerId);
-      expect(issuer.status).toBe(404);
-      expect(issuer.data.status).toBe(404);
-      expect(issuer.data.statusCode).toBe(404);
-      expect(issuer.data.message).toBe(`The issuer '${issuerId}' is not associated with the account`);
+      expectMore(issuer).toBeHttpError(404, `The issuer '${issuerId}' is not associated with the account`);
+    }, 10000);
+
+    test('Getting an issuer with a malformed account should return an error', async () => {
+      const issuerId = `test-${random()}`;
+      const publicKeys = [{ publicKey: 'bar', keyId: 'kid-0' }];
+      await addIssuer(account, issuerId, { publicKeys, displayName: 'fuzz' });
+
+      const malformed = await getMalformedAccount();
+      const issuer = await removeIssuer(malformed, issuerId);
+      expectMore(issuer).toBeMalformedAccountError(malformed.accountId);
     }, 10000);
 
     test('Getting an issuer with a non-existing account should return an error', async () => {
@@ -47,13 +50,8 @@ describe('Issuer', () => {
       const publicKeys = [{ publicKey: 'bar', keyId: 'kid-0' }];
       await addIssuer(account, issuerId, { publicKeys, displayName: 'fuzz' });
 
-      const issuer = await removeIssuer(invalidAccount, issuerId);
-      expect(issuer.status).toBe(404);
-      expect(issuer.data.status).toBe(404);
-      expect(issuer.data.statusCode).toBe(404);
-
-      const message = issuer.data.message.replace(/'[^']*'/, '<issuer>');
-      expect(message).toBe(`The issuer <issuer> is not associated with the account`);
+      const issuer = await removeIssuer(await getNonExistingAccount(), issuerId);
+      expectMore(issuer).toBeUnauthorizedError();
     }, 10000);
   });
 });

--- a/api/function-api/test/issuer.update.test.ts
+++ b/api/function-api/test/issuer.update.test.ts
@@ -1,18 +1,13 @@
 import { random } from '@5qtrs/random';
-import { IAccount, FakeAccount, resolveAccount } from './accountResolver';
+import { IAccount, FakeAccount, resolveAccount, getMalformedAccount, getNonExistingAccount } from './accountResolver';
 import { addIssuer, updateIssuer, cleanUpIssuers } from './sdk';
+import { extendExpect } from './extendJest';
+
+const expectMore = extendExpect(expect);
 
 let account: IAccount = FakeAccount;
-let invalidAccount: IAccount = FakeAccount;
-
 beforeAll(async () => {
   account = await resolveAccount();
-  invalidAccount = {
-    accountId: 'acc-9999999999999999',
-    subscriptionId: account.subscriptionId,
-    baseUrl: account.baseUrl,
-    accessToken: account.accessToken,
-  };
 });
 
 afterEach(async () => {
@@ -101,10 +96,10 @@ describe('Issuer', () => {
 
       const publicKeys = [{ publicKey: 'bar', keyId: 'kid-0' }];
       const issuer = await updateIssuer(account, issuerId, { publicKeys, jsonKeysUrl: 'foo' });
-      expect(issuer.status).toBe(400);
-      expect(issuer.data.status).toBe(400);
-      expect(issuer.data.statusCode).toBe(400);
-      expect(issuer.data.message).toBe(`The issuer '${issuerId}' can not have both public keys and a json keys URL`);
+      expectMore(issuer).toBeHttpError(
+        400,
+        `The issuer '${issuerId}' can not have both public keys and a json keys URL`
+      );
     }, 10000);
 
     test('Updating an issuer with empty string jsonKeysUrl is be supported', async () => {
@@ -112,10 +107,7 @@ describe('Issuer', () => {
       await addIssuer(account, issuerId, { jsonKeysUrl: 'foo' });
 
       const issuer = await updateIssuer(account, issuerId, { jsonKeysUrl: '' });
-      expect(issuer.status).toBe(400);
-      expect(issuer.data.status).toBe(400);
-      expect(issuer.data.statusCode).toBe(400);
-      expect(issuer.data.message).toBe('"jsonKeysUrl" is not allowed to be empty');
+      expectMore(issuer).toBeHttpError(400, '"jsonKeysUrl" is not allowed to be empty');
     }, 10000);
 
     test('Updating an issuer with empty string displayName is be supported', async () => {
@@ -123,10 +115,7 @@ describe('Issuer', () => {
       await addIssuer(account, issuerId, { jsonKeysUrl: 'foo' });
 
       const issuer = await updateIssuer(account, issuerId, { displayName: '' });
-      expect(issuer.status).toBe(400);
-      expect(issuer.data.status).toBe(400);
-      expect(issuer.data.statusCode).toBe(400);
-      expect(issuer.data.message).toBe('"displayName" is not allowed to be empty');
+      expectMore(issuer).toBeHttpError(400, '"displayName" is not allowed to be empty');
     }, 10000);
 
     test('Updating an issuer with four publicKeys is not supported', async () => {
@@ -162,10 +151,7 @@ describe('Issuer', () => {
       await addIssuer(account, issuerId, { jsonKeysUrl: 'foo' });
 
       const issuer = await updateIssuer(account, issuerId, { publicKeys: [] });
-      expect(issuer.status).toBe(400);
-      expect(issuer.data.status).toBe(400);
-      expect(issuer.data.statusCode).toBe(400);
-      expect(issuer.data.message).toBe(`"publicKeys" must contain at least 1 items`);
+      expectMore(issuer).toBeHttpError(400, `"publicKeys" must contain at least 1 items`);
     }, 10000);
 
     test('Updating an issuer with a publicKey without a key id is not supported', async () => {
@@ -173,10 +159,7 @@ describe('Issuer', () => {
       await addIssuer(account, issuerId, { jsonKeysUrl: 'foo' });
 
       const issuer = await updateIssuer(account, issuerId, { publicKeys: [{ publicKey: 'bar' }] });
-      expect(issuer.status).toBe(400);
-      expect(issuer.data.status).toBe(400);
-      expect(issuer.data.statusCode).toBe(400);
-      expect(issuer.data.message).toBe('"keyId" is required');
+      expectMore(issuer).toBeHttpError(400, '"keyId" is required');
     }, 10000);
 
     test('Updating an issuer with a publicKey with an empty key id is not supported', async () => {
@@ -184,10 +167,7 @@ describe('Issuer', () => {
       await addIssuer(account, issuerId, { jsonKeysUrl: 'foo' });
 
       const issuer = await updateIssuer(account, issuerId, { publicKeys: [{ publicKey: 'bar', keyId: '' }] });
-      expect(issuer.status).toBe(400);
-      expect(issuer.data.status).toBe(400);
-      expect(issuer.data.statusCode).toBe(400);
-      expect(issuer.data.message).toBe('"keyId" is not allowed to be empty');
+      expectMore(issuer).toBeHttpError(400, '"keyId" is not allowed to be empty');
     }, 10000);
 
     test('Updating an issuer with a publicKey without an actual publicKey is not supported', async () => {
@@ -195,10 +175,7 @@ describe('Issuer', () => {
       await addIssuer(account, issuerId, { jsonKeysUrl: 'foo' });
 
       const issuer = await updateIssuer(account, issuerId, { publicKeys: [{ keyId: 'bar' }] });
-      expect(issuer.status).toBe(400);
-      expect(issuer.data.status).toBe(400);
-      expect(issuer.data.statusCode).toBe(400);
-      expect(issuer.data.message).toBe('"publicKey" is required');
+      expectMore(issuer).toBeHttpError(400, '"publicKey" is required');
     }, 10000);
 
     test('Updating an issuer with a publicKey with an empty publicKey is not supported', async () => {
@@ -206,10 +183,7 @@ describe('Issuer', () => {
       await addIssuer(account, issuerId, { jsonKeysUrl: 'foo' });
 
       const issuer = await updateIssuer(account, issuerId, { publicKeys: [{ keyId: 'bar', publicKey: '' }] });
-      expect(issuer.status).toBe(400);
-      expect(issuer.data.status).toBe(400);
-      expect(issuer.data.statusCode).toBe(400);
-      expect(issuer.data.message).toBe('"publicKey" is not allowed to be empty');
+      expectMore(issuer).toBeHttpError(400, '"publicKey" is not allowed to be empty');
     }, 10000);
 
     test('Updating a non-existing issuer should return an error', async () => {
@@ -217,10 +191,17 @@ describe('Issuer', () => {
       const publicKeys = [{ publicKey: 'bar', keyId: 'kid-0' }];
 
       const issuer = await updateIssuer(account, issuerId, { publicKeys });
-      expect(issuer.status).toBe(404);
-      expect(issuer.data.status).toBe(404);
-      expect(issuer.data.statusCode).toBe(404);
-      expect(issuer.data.message).toBe(`The issuer '${issuerId}' is not associated with the account`);
+      expectMore(issuer).toBeHttpError(404, `The issuer '${issuerId}' is not associated with the account`);
+    }, 10000);
+
+    test('Getting an issuer with a malformed account should return an error', async () => {
+      const issuerId = `test-${random()}`;
+      const publicKeys = [{ publicKey: 'bar', keyId: 'kid-0' }];
+      await addIssuer(account, issuerId, { publicKeys });
+
+      const malformed = await getMalformedAccount();
+      const issuer = await updateIssuer(malformed, issuerId, { publicKeys });
+      expectMore(issuer).toBeMalformedAccountError(malformed.accountId);
     }, 10000);
 
     test('Getting an issuer with a non-existing account should return an error', async () => {
@@ -228,13 +209,8 @@ describe('Issuer', () => {
       const publicKeys = [{ publicKey: 'bar', keyId: 'kid-0' }];
       await addIssuer(account, issuerId, { publicKeys });
 
-      const issuer = await updateIssuer(invalidAccount, issuerId, { publicKeys });
-      expect(issuer.status).toBe(404);
-      expect(issuer.data.status).toBe(404);
-      expect(issuer.data.statusCode).toBe(404);
-
-      const message = issuer.data.message.replace(/'[^']*'/, '<issuer>');
-      expect(message).toBe(`The issuer <issuer> is not associated with the account`);
+      const issuer = await updateIssuer(await getNonExistingAccount(), issuerId, { publicKeys });
+      expectMore(issuer).toBeUnauthorizedError();
     }, 10000);
   });
 });

--- a/api/function-api/test/user.add.test.ts
+++ b/api/function-api/test/user.add.test.ts
@@ -1,18 +1,13 @@
-import { IAccount, FakeAccount, resolveAccount } from './accountResolver';
+import { IAccount, FakeAccount, resolveAccount, getMalformedAccount, getNonExistingAccount } from './accountResolver';
 import { addUser, addClient, cleanUpUsers } from './sdk';
 import { random } from '@5qtrs/random';
+import { extendExpect } from './extendJest';
+
+const expectMore = extendExpect(expect);
 
 let account: IAccount = FakeAccount;
-let invalidAccount: IAccount = FakeAccount;
-
 beforeAll(async () => {
   account = await resolveAccount();
-  invalidAccount = {
-    accountId: 'acc-9999999999999999',
-    subscriptionId: account.subscriptionId,
-    baseUrl: account.baseUrl,
-    accessToken: account.accessToken,
-  };
 });
 
 afterEach(async () => {
@@ -113,26 +108,17 @@ describe('User', () => {
 
     test('Adding a user with an empty string first name is not supported', async () => {
       const user = await addUser(account, { firstName: '' });
-      expect(user.status).toBe(400);
-      expect(user.data.status).toBe(400);
-      expect(user.data.statusCode).toBe(400);
-      expect(user.data.message).toBe('"firstName" is not allowed to be empty');
+      expectMore(user).toBeHttpError(400, '"firstName" is not allowed to be empty');
     }, 20000);
 
     test('Adding a user with an empty string last name is not supported', async () => {
       const user = await addUser(account, { lastName: '' });
-      expect(user.status).toBe(400);
-      expect(user.data.status).toBe(400);
-      expect(user.data.statusCode).toBe(400);
-      expect(user.data.message).toBe('"lastName" is not allowed to be empty');
+      expectMore(user).toBeHttpError(400, '"lastName" is not allowed to be empty');
     }, 20000);
 
     test('Adding a user with an empty string primary email is not supported', async () => {
       const user = await addUser(account, { primaryEmail: '' });
-      expect(user.status).toBe(400);
-      expect(user.data.status).toBe(400);
-      expect(user.data.statusCode).toBe(400);
-      expect(user.data.message).toBe('"primaryEmail" is not allowed to be empty');
+      expectMore(user).toBeHttpError(400, '"primaryEmail" is not allowed to be empty');
     }, 20000);
 
     test('Adding a user with an exisitng identity returns an error', async () => {
@@ -140,10 +126,8 @@ describe('User', () => {
       const identities = [{ issuerId: 'test', subject }];
       await addUser(account, { identities });
       const user = await addUser(account, { identities });
-      expect(user.status).toBe(400);
-      expect(user.data.status).toBe(400);
-      expect(user.data.statusCode).toBe(400);
-      expect(user.data.message).toBe(
+      expectMore(user).toBeHttpError(
+        400,
         `The identity with issuer 'test' and subject '${subject}' is already associated with a user or client`
       );
     }, 20000);
@@ -153,10 +137,8 @@ describe('User', () => {
       const identities = [{ issuerId: 'test', subject }];
       await addClient(account, { identities });
       const user = await addUser(account, { identities });
-      expect(user.status).toBe(400);
-      expect(user.data.status).toBe(400);
-      expect(user.data.statusCode).toBe(400);
-      expect(user.data.message).toBe(
+      expectMore(user).toBeHttpError(
+        400,
         `The identity with issuer 'test' and subject '${subject}' is already associated with a user or client`
       );
     }, 20000);
@@ -164,110 +146,78 @@ describe('User', () => {
     test('Adding a user with an identity with an empty issuerId is not supported', async () => {
       const identities = [{ issuerId: '', subject: `sub-${random()}` }];
       const user = await addUser(account, { identities });
-      expect(user.status).toBe(400);
-      expect(user.data.status).toBe(400);
-      expect(user.data.statusCode).toBe(400);
-      expect(user.data.message).toBe('"issuerId" is not allowed to be empty');
+      expectMore(user).toBeHttpError(400, '"issuerId" is not allowed to be empty');
     }, 20000);
 
     test('Adding a user with an identity with a missing issuerId is not supported', async () => {
       const identities = [{ subject: `sub-${random()}` }];
       const user = await addUser(account, { identities });
-      expect(user.status).toBe(400);
-      expect(user.data.status).toBe(400);
-      expect(user.data.statusCode).toBe(400);
-      expect(user.data.message).toBe('"issuerId" is required');
+      expectMore(user).toBeHttpError(400, '"issuerId" is required');
     }, 20000);
 
     test('Adding a user with an identity with an empty subject is not supported', async () => {
       const identities = [{ issuerId: 'foo', subject: '' }];
       const user = await addUser(account, { identities });
-      expect(user.status).toBe(400);
-      expect(user.data.status).toBe(400);
-      expect(user.data.statusCode).toBe(400);
-      expect(user.data.message).toBe('"subject" is not allowed to be empty');
+      expectMore(user).toBeHttpError(400, '"subject" is not allowed to be empty');
     }, 20000);
 
     test('Adding a user with an identity with a missing subject is not supported', async () => {
       const identities = [{ issuerId: 'foo' }];
       const user = await addUser(account, { identities });
-      expect(user.status).toBe(400);
-      expect(user.data.status).toBe(400);
-      expect(user.data.statusCode).toBe(400);
-      expect(user.data.message).toBe('"subject" is required');
+      expectMore(user).toBeHttpError(400, '"subject" is required');
     }, 20000);
 
     test('Adding a user with access with an empty action is not supported', async () => {
       const access = { allow: [{ action: '', resource: '/' }] };
       const user = await addUser(account, { access });
-      expect(user.status).toBe(400);
-      expect(user.data.status).toBe(400);
-      expect(user.data.statusCode).toBe(400);
-      expect(user.data.message).toBe('"action" is not allowed to be empty');
+      expectMore(user).toBeHttpError(400, '"action" is not allowed to be empty');
     }, 20000);
 
     test('Adding a user with access with a missing action is not supported', async () => {
       const access = { allow: [{ resource: '/' }] };
       const user = await addUser(account, { access });
-      expect(user.status).toBe(400);
-      expect(user.data.status).toBe(400);
-      expect(user.data.statusCode).toBe(400);
-      expect(user.data.message).toBe('"action" is required');
+      expectMore(user).toBeHttpError(400, '"action" is required');
     }, 20000);
 
     test('Adding a user with access with an empty resource is not supported', async () => {
       const access = { allow: [{ action: '*', resource: '' }] };
       const user = await addUser(account, { access });
-      expect(user.status).toBe(400);
-      expect(user.data.status).toBe(400);
-      expect(user.data.statusCode).toBe(400);
-      expect(user.data.message).toBe('"resource" is not allowed to be empty');
+      expectMore(user).toBeHttpError(400, '"resource" is not allowed to be empty');
     }, 20000);
 
     test('Adding a user with access with a missing resource is not supported', async () => {
       const access = { allow: [{ action: '*' }] };
       const user = await addUser(account, { access });
-      expect(user.status).toBe(400);
-      expect(user.data.status).toBe(400);
-      expect(user.data.statusCode).toBe(400);
-      expect(user.data.message).toBe('"resource" is required');
+      expectMore(user).toBeHttpError(400, '"resource" is required');
     }, 20000);
 
     test('Adding a user with access with no allow is not supported', async () => {
       const access = {};
       const user = await addUser(account, { access });
-      expect(user.status).toBe(400);
-      expect(user.data.status).toBe(400);
-      expect(user.data.statusCode).toBe(400);
-      expect(user.data.message).toBe('"allow" is required');
+      expectMore(user).toBeHttpError(400, '"allow" is required');
     }, 20000);
 
     test('Adding a user with access with an empty allow array is not supported', async () => {
       const access = { allow: [] };
       const user = await addUser(account, { access });
-      expect(user.status).toBe(400);
-      expect(user.data.status).toBe(400);
-      expect(user.data.statusCode).toBe(400);
-      expect(user.data.message).toBe('"allow" must contain at least 1 items');
+      expectMore(user).toBeHttpError(400, '"allow" must contain at least 1 items');
     }, 20000);
 
     test('Adding a user with identities with an empty array is not supported', async () => {
       const identities: any = [];
       const user = await addUser(account, { identities });
-      expect(user.status).toBe(400);
-      expect(user.data.status).toBe(400);
-      expect(user.data.statusCode).toBe(400);
-      expect(user.data.message).toBe('"identities" must contain at least 1 items');
+      expectMore(user).toBeHttpError(400, '"identities" must contain at least 1 items');
     }, 20000);
+
+    test('Adding a user with a malformed account should return an error', async () => {
+      const malformed = await getMalformedAccount();
+      const user = await addUser(malformed, {});
+      expectMore(user).toBeMalformedAccountError(malformed.accountId);
+    }, 10000);
 
     test('Adding a user with a non-existing account should return an error', async () => {
-      const user = await addUser(invalidAccount, {});
-      expect(user.status).toBe(404);
-      expect(user.data.status).toBe(404);
-      expect(user.data.statusCode).toBe(404);
-
-      const message = user.data.message.replace(/'[^']*'/, '<issuer>');
-      expect(message).toBe(`The issuer <issuer> is not associated with the account`);
-    }, 20000);
+      const user = await addUser(await getNonExistingAccount(), {});
+      expectMore(user).toBeUnauthorizedError();
+    }, 10000);
   });
 });

--- a/api/function-api/test/user.remove.test.ts
+++ b/api/function-api/test/user.remove.test.ts
@@ -1,18 +1,14 @@
-import { IAccount, FakeAccount, resolveAccount } from './accountResolver';
-import { addUser, getUser, removeUser, cleanUpUsers } from './sdk';
 import { random } from '@5qtrs/random';
+import { IAccount, FakeAccount, resolveAccount, getMalformedAccount, getNonExistingAccount } from './accountResolver';
+import { addUser, getUser, removeUser, cleanUpUsers } from './sdk';
+import { extendExpect } from './extendJest';
+
+const expectMore = extendExpect(expect);
 
 let account: IAccount = FakeAccount;
-let invalidAccount: IAccount = FakeAccount;
 
 beforeAll(async () => {
   account = await resolveAccount();
-  invalidAccount = {
-    accountId: 'acc-9999999999999999',
-    subscriptionId: account.subscriptionId,
-    baseUrl: account.baseUrl,
-    accessToken: account.accessToken,
-  };
 });
 
 afterEach(async () => {
@@ -21,7 +17,7 @@ afterEach(async () => {
 
 describe('User', () => {
   describe('Remove', () => {
-    test('Getting a user should be supported', async () => {
+    test('Removing a user should be supported', async () => {
       const identities = [{ issuerId: 'test', subject: `sub-${random()}` }];
       const access = { allow: [{ action: 'user:*', resource: '/account/abc/' }] };
       const original = await addUser(account, {
@@ -36,16 +32,14 @@ describe('User', () => {
       expect(user.data).toBeUndefined();
 
       const removed = await getUser(account, original.data.id);
-      expect(removed.status).toBe(404);
+      expectMore(removed).toBeHttpError(404, `The user '${original.data.id}' does not exist`);
     }, 20000);
 
     test('Removing a user with an invalid user id should return an error', async () => {
       const userId = `usr-${random()}`;
       const user = await removeUser(account, userId);
-      expect(user.status).toBe(400);
-      expect(user.data.status).toBe(400);
-      expect(user.data.statusCode).toBe(400);
-      expect(user.data.message).toBe(
+      expectMore(user).toBeHttpError(
+        400,
         `"userId" with value "${userId}" fails to match the required pattern: /^usr-[a-g0-9]{16}$/`
       );
     }, 20000);
@@ -53,21 +47,20 @@ describe('User', () => {
     test('Removing a non-existing user should return an error', async () => {
       const userId = `usr-${random({ lengthInBytes: 8 })}`;
       const user = await removeUser(account, userId);
-      expect(user.status).toBe(404);
-      expect(user.data.status).toBe(404);
-      expect(user.data.statusCode).toBe(404);
-      expect(user.data.message).toBe(`The user '${userId}' does not exist`);
+      expectMore(user).toBeHttpError(404, `The user '${userId}' does not exist`);
     }, 20000);
 
-    test('Removing an user with a non-existing account should return an error', async () => {
+    test('Removing a user with a mal-formed account should return an error', async () => {
+      const malformed = await getMalformedAccount();
       const original = await addUser(account, {});
-      const user = await removeUser(invalidAccount, original.data.id);
-      expect(user.status).toBe(404);
-      expect(user.data.status).toBe(404);
-      expect(user.data.statusCode).toBe(404);
+      const user = await removeUser(malformed, original.data.id);
+      expectMore(user).toBeMalformedAccountError(malformed.accountId);
+    }, 10000);
 
-      const message = user.data.message.replace(/'[^']*'/, '<issuer>');
-      expect(message).toBe(`The issuer <issuer> is not associated with the account`);
+    test('Removing a user with a non-existing account should return an error', async () => {
+      const original = await addUser(account, {});
+      const user = await removeUser(await getNonExistingAccount(), original.data.id);
+      expectMore(user).toBeUnauthorizedError();
     }, 10000);
   });
 });

--- a/lib/data/account-data/src/AccountDataException.ts
+++ b/lib/data/account-data/src/AccountDataException.ts
@@ -23,6 +23,7 @@ export enum AccountDataExceptionCode {
   idRequired = 'idRequired',
   unauthorized = 'unauthorized',
   unauthorizedToGrantAccess = 'unauthorizedToGrantAccess',
+  unresolvedAgent = 'unresolvedAgent',
   invalidJwt = 'invalidJwt',
   noPublicKey = 'noPublicKey',
   invalidNext = 'invalidNext',
@@ -71,6 +72,11 @@ export class AccountDataException extends Exception {
   public static noIssuer(issuerId: string) {
     const message = `The issuer '${issuerId}' is not associated with the account`;
     return new AccountDataException(AccountDataExceptionCode.noIssuer, message, [issuerId]);
+  }
+
+  public static unresolvedAgent(error: Error) {
+    const message = `Unable to resolve the agent due to the following error: ${error.message}`;
+    return new AccountDataException(AccountDataExceptionCode.unresolvedAgent, message, [error]);
   }
 
   public static noAgent(agentId: string) {

--- a/lib/server/account/src/Init.ts
+++ b/lib/server/account/src/Init.ts
@@ -114,6 +114,11 @@ export class Init {
     if (!decodedJwt.agentId) {
       throw AccountDataException.invalidJwt(new Error("Init jwt missing 'agentId' field"));
     }
+    if (accountId !== decodedJwt.accountId) {
+      throw AccountDataException.invalidJwt(
+        new Error("Jwt 'accountId' field value does not match URL accountId value")
+      );
+    }
 
     const jwtSecret = await this.dataContext.agentData.resolve(decodedJwt.accountId, decodedJwt.agentId);
 


### PR DESCRIPTION
- Introduces shared test code for testing HTTP errors from the API
- Updates all accounts src code and tests to properly return 403 if access token does not match the accountId in the URL--regardless if the accountId in the url exists or not
- Fixed: `from` and `to` - provide examples of the Date formats accepted
- Fixed: Check all `resource` examples to make sure account IDs are valid
- Fixed: `AccountAuditEntry` entry needs to show whether authorization succeeded or failed. Note that this is entries for failed authz not failed authn
- Fixed: Document that for all query parameters it's a logical AND
- Fixed: go through and make sure 400 errors are accurately reflected in the Swagger everywhere