### PR TITLE
allow id on PATCH, delete function 404 support

### DIFF
--- a/api/function-api/src/routes/handlers/client.js
+++ b/api/function-api/src/routes/handlers/client.js
@@ -1,4 +1,5 @@
 const { getAccountContext, getBaseUrl, errorHandler } = require('../account');
+const create_error = require('http-errors');
 
 function clientPost() {
   return (req, res) => {
@@ -16,13 +17,21 @@ function clientPost() {
 }
 
 function clientPatch() {
-  return (req, res) => {
+  return (req, res, next) => {
     getAccountContext().then(accountContext => {
       const resolvedAgent = req.resolvedAgent;
       const accountId = req.params.accountId;
       const clientId = req.params.clientId;
       const updateClient = req.body;
-      updateClient.id = clientId;
+      if (updateClient.id && updateClient.id !== clientId) {
+        const message = [
+          `The clientId in the body '${updateClient.id}'`,
+          `does not match the clientId in the URL '${clientId}'`,
+        ].join(' ');
+        return next(new create_error(400, message));
+      } else {
+        updateClient.id = clientId;
+      }
 
       accountContext.client
         .update(resolvedAgent, accountId, updateClient)

--- a/api/function-api/src/routes/handlers/issuer.js
+++ b/api/function-api/src/routes/handlers/issuer.js
@@ -1,4 +1,5 @@
 const { getAccountContext, errorHandler } = require('../account');
+const create_error = require('http-errors');
 
 function issuerPost() {
   return (req, res) => {
@@ -18,13 +19,21 @@ function issuerPost() {
 }
 
 function issuerPatch() {
-  return (req, res) => {
+  return (req, res, next) => {
     getAccountContext().then(accountContext => {
       const resolvedAgent = req.resolvedAgent;
       const accountId = req.params.accountId;
       const issuerId = req.params.issuerId;
       const updateIssuer = req.body;
-      updateIssuer.id = issuerId;
+      if (updateIssuer.id && updateIssuer.id !== issuerId) {
+        const message = [
+          `The issuerId in the body '${updateIssuer.id}'`,
+          `does not match the issuerId in the URL '${issuerId}'`,
+        ].join(' ');
+        return next(new create_error(400, message));
+      } else {
+        updateIssuer.id = issuerId;
+      }
 
       accountContext.issuer
         .update(resolvedAgent, accountId, updateIssuer)

--- a/api/function-api/src/routes/handlers/user.js
+++ b/api/function-api/src/routes/handlers/user.js
@@ -1,4 +1,5 @@
 const { getAccountContext, getBaseUrl, errorHandler } = require('../account');
+const create_error = require('http-errors');
 
 function userPost() {
   return (req, res) => {
@@ -16,13 +17,21 @@ function userPost() {
 }
 
 function userPatch() {
-  return (req, res) => {
+  return (req, res, next) => {
     getAccountContext().then(accountContext => {
       const resolvedAgent = req.resolvedAgent;
       const accountId = req.params.accountId;
       const userId = req.params.userId;
       const updateUser = req.body;
-      updateUser.id = userId;
+      if (updateUser.id && updateUser.id !== userId) {
+        const message = [
+          `The userId in the body '${updateUser.id}'`,
+          `does not match the userId in the URL '${userId}'`,
+        ].join(' ');
+        return next(new create_error(400, message));
+      } else {
+        updateUser.id = userId;
+      }
 
       accountContext.user
         .update(resolvedAgent, accountId, updateUser)

--- a/api/function-api/src/routes/schemas/agent.js
+++ b/api/function-api/src/routes/schemas/agent.js
@@ -1,0 +1,23 @@
+const Joi = require('joi');
+
+module.exports = Joi.object().keys({
+  identities: Joi.array()
+    .min(1)
+    .items(
+      Joi.object().keys({
+        issuerId: Joi.string().required(),
+        subject: Joi.string().required(),
+      })
+    ),
+  access: Joi.object().keys({
+    allow: Joi.array()
+      .required()
+      .min(1)
+      .items(
+        Joi.object().keys({
+          action: Joi.string().required(),
+          resource: Joi.string().required(),
+        })
+      ),
+  }),
+});

--- a/api/function-api/src/routes/schemas/client.js
+++ b/api/function-api/src/routes/schemas/client.js
@@ -1,24 +1,6 @@
 const Joi = require('joi');
+const agent = require('./agent');
 
-module.exports = Joi.object().keys({
+module.exports = agent.keys({
   displayName: Joi.string(),
-  identities: Joi.array()
-    .min(1)
-    .items(
-      Joi.object().keys({
-        issuerId: Joi.string().required(),
-        subject: Joi.string().required(),
-      })
-    ),
-  access: Joi.object().keys({
-    allow: Joi.array()
-      .required()
-      .min(1)
-      .items(
-        Joi.object().keys({
-          action: Joi.string().required(),
-          resource: Joi.string().required(),
-        })
-      ),
-  }),
 });

--- a/api/function-api/src/routes/schemas/update_client.js
+++ b/api/function-api/src/routes/schemas/update_client.js
@@ -1,0 +1,6 @@
+const Joi = require('joi');
+const client = require('./client');
+
+module.exports = client.keys({
+  id: Joi.string().regex(/^clt-[a-g0-9]{16}$/),
+});

--- a/api/function-api/src/routes/schemas/update_issuer.js
+++ b/api/function-api/src/routes/schemas/update_issuer.js
@@ -1,0 +1,6 @@
+const Joi = require('joi');
+const issuer = require('./issuer');
+
+module.exports = issuer.keys({
+  id: Joi.string(),
+});

--- a/api/function-api/src/routes/schemas/update_user.js
+++ b/api/function-api/src/routes/schemas/update_user.js
@@ -1,0 +1,6 @@
+const Joi = require('joi');
+const user = require('./user');
+
+module.exports = user.keys({
+  id: Joi.string().regex(/^usr-[a-g0-9]{16}$/),
+});

--- a/api/function-api/src/routes/schemas/user.js
+++ b/api/function-api/src/routes/schemas/user.js
@@ -1,26 +1,8 @@
 const Joi = require('joi');
+const agent = require('./agent');
 
-module.exports = Joi.object().keys({
+module.exports = agent.keys({
   firstName: Joi.string(),
   lastName: Joi.string(),
   primaryEmail: Joi.string(),
-  identities: Joi.array()
-    .min(1)
-    .items(
-      Joi.object().keys({
-        issuerId: Joi.string().required(),
-        subject: Joi.string().required(),
-      })
-    ),
-  access: Joi.object().keys({
-    allow: Joi.array()
-      .required()
-      .min(1)
-      .items(
-        Joi.object().keys({
-          action: Joi.string().required(),
-          resource: Joi.string().required(),
-        })
-      ),
-  }),
 });

--- a/api/function-api/src/routes/v1_api.js
+++ b/api/function-api/src/routes/v1_api.js
@@ -135,7 +135,7 @@ router.patch(
   authorize({ operation: AccountActions.updateIssuer }),
   express.json(),
   validate_schema({
-    body: require('./schemas/issuer'),
+    body: require('./schemas/update_issuer'),
   }),
   issuer.issuerPatch()
 );
@@ -240,7 +240,7 @@ router.patch(
   express.json(),
   validate_schema({
     params: require('./schemas/api_params'),
-    body: require('./schemas/user'),
+    body: require('./schemas/update_user'),
   }),
   user.userPatch()
 );
@@ -328,7 +328,7 @@ router.patch(
   express.json(),
   validate_schema({
     params: require('./schemas/api_params'),
-    body: require('./schemas/client'),
+    body: require('./schemas/update_client'),
   }),
   client.clientPatch()
 );

--- a/api/function-api/test/client.add.test.ts
+++ b/api/function-api/test/client.add.test.ts
@@ -99,6 +99,13 @@ describe('Client', () => {
       );
     }, 20000);
 
+    test('Adding a client with an id returns an error', async () => {
+      const subject = `sub-${random()}`;
+      const identities = [{ id: 'clt-5555555555555555', issuerId: 'test', subject }];
+      const client = await addClient(account, { identities });
+      expectMore(client).toBeHttpError(400, '"id" is not allowed');
+    }, 20000);
+
     test('Adding a client with an exisitng user identity returns an error', async () => {
       const subject = `sub-${random()}`;
       const identities = [{ issuerId: 'test', subject }];

--- a/api/function-api/test/client.update.test.ts
+++ b/api/function-api/test/client.update.test.ts
@@ -172,6 +172,27 @@ describe('Client', () => {
       expect(client.data.id.indexOf('clt-')).toBe(0);
     }, 20000);
 
+    test('Updating a client with the id in the body should be supported', async () => {
+      const original = await addClient(account, { displayName: 'displayName - test client' });
+      const client = await updateClient(account, original.data.id, { id: original.data.id, displayName: 'updated' });
+      expect(client.status).toBe(200);
+      expect(client.data.id).toBeDefined();
+      expect(client.data.displayName).toBe('updated');
+      expect(client.data.identities).toBeUndefined();
+      expect(client.data.access).toBeUndefined();
+      expect(client.data.id.indexOf('clt-')).toBe(0);
+    }, 20000);
+
+    test('Updating a client with an id in the body that does not match the url returns an error', async () => {
+      const original = await addClient(account, { displayName: 'displayName - test client' });
+      const id = 'clt-5555555555555555';
+      const client = await updateClient(account, original.data.id, { id, displayName: 'updated' });
+      expectMore(client).toBeHttpError(
+        400,
+        `The clientId in the body '${id}' does not match the clientId in the URL '${original.data.id}'`
+      );
+    }, 20000);
+
     test('Updating a client with an empty string display name is not supported', async () => {
       const original = await addClient(account, { displayName: 'displayName - test client' });
       const client = await updateClient(account, original.data.id, { displayName: '' });

--- a/api/function-api/test/function.test.ts
+++ b/api/function-api/test/function.test.ts
@@ -132,6 +132,31 @@ describe('function', () => {
     });
   });
 
+  test('DELETE on a non-existing function returns 404', async () => {
+    const response = await deleteFunction(account, boundaryId, 'no-such-function');
+    expect(response.status).toEqual(404);
+    expect(response.data).toMatchObject({
+      status: 404,
+      statusCode: 404,
+      message: 'Not Found',
+    });
+  });
+
+  test('DELETE on a deleted function returns 404', async () => {
+    let response = await putFunction(account, boundaryId, function1Id, helloWorld);
+    expect(response.status).toEqual(200);
+    response = await deleteFunction(account, boundaryId, function1Id);
+    expect(response.status).toEqual(204);
+    expect(response.data).toBeUndefined();
+    response = await deleteFunction(account, boundaryId, function1Id);
+    expect(response.status).toEqual(404);
+    expect(response.data).toMatchObject({
+      status: 404,
+      statusCode: 404,
+      message: 'Not Found',
+    });
+  });
+
   test('GET retrieves information of simple function', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorld);
     expect(response.status).toEqual(200);

--- a/api/function-api/test/issuer.add.test.ts
+++ b/api/function-api/test/issuer.add.test.ts
@@ -139,6 +139,15 @@ describe('Issuer', () => {
       expectMore(issuer).toBeHttpError(400, '"publicKey" is not allowed to be empty');
     }, 10000);
 
+    test('Adding an issuer with an id returns an error', async () => {
+      const issuerId = `test-${random()}`;
+      const issuer = await addIssuer(account, issuerId, {
+        id: issuerId,
+        publicKeys: [{ publicKey: 'foo', keyId: 'bar' }],
+      });
+      expectMore(issuer).toBeHttpError(400, '"id" is not allowed');
+    }, 20000);
+
     test('Adding an issuer that already exists is not supported', async () => {
       const issuerId = `test-${random()}`;
       const issuer1 = await addIssuer(account, issuerId, { publicKeys: [{ publicKey: 'foo', keyId: 'bar' }] });

--- a/api/function-api/test/issuer.update.test.ts
+++ b/api/function-api/test/issuer.update.test.ts
@@ -118,6 +118,27 @@ describe('Issuer', () => {
       expectMore(issuer).toBeHttpError(400, '"displayName" is not allowed to be empty');
     }, 10000);
 
+    test('Updating an issuer with the id in the body should be supported', async () => {
+      const issuerId = `test-${random()}`;
+      await addIssuer(account, issuerId, { jsonKeysUrl: 'foo' });
+      const issuer = await updateIssuer(account, issuerId, { id: issuerId, jsonKeysUrl: 'updated' });
+      expect(issuer.status).toBe(200);
+      expect(issuer.data.id).toBeDefined();
+      expect(issuer.data.jsonKeysUrl).toBe('updated');
+      expect(issuer.data.id).toBe(issuerId);
+    }, 10000);
+
+    test.only('Updating an issuer with an id in the body that does not match the url returns an error', async () => {
+      const issuerId = `test-${random()}`;
+      await addIssuer(account, issuerId, { jsonKeysUrl: 'foo' });
+      const id = 'other-issuer-id';
+      const issuer = await updateIssuer(account, issuerId, { id, jsonKeysUrl: 'updated' });
+      expectMore(issuer).toBeHttpError(
+        400,
+        `The issuerId in the body '${id}' does not match the issuerId in the URL '${issuerId}'`
+      );
+    }, 10000);
+
     test('Updating an issuer with four publicKeys is not supported', async () => {
       const issuerId = `test-${random()}`;
       await addIssuer(account, issuerId, { jsonKeysUrl: 'foo' });

--- a/api/function-api/test/user.add.test.ts
+++ b/api/function-api/test/user.add.test.ts
@@ -106,6 +106,13 @@ describe('User', () => {
       expect(user.data.id.indexOf('usr-')).toBe(0);
     }, 20000);
 
+    test('Adding a user with an id returns an error', async () => {
+      const subject = `sub-${random()}`;
+      const identities = [{ id: 'usr-5555555555555555', issuerId: 'test', subject }];
+      const client = await addClient(account, { identities });
+      expectMore(client).toBeHttpError(400, '"id" is not allowed');
+    }, 20000);
+
     test('Adding a user with an empty string first name is not supported', async () => {
       const user = await addUser(account, { firstName: '' });
       expectMore(user).toBeHttpError(400, '"firstName" is not allowed to be empty');

--- a/api/function-api/test/user.update.test.ts
+++ b/api/function-api/test/user.update.test.ts
@@ -288,6 +288,27 @@ describe('User', () => {
       expect(user.data.id.indexOf('usr-')).toBe(0);
     }, 20000);
 
+    test('Updating a user with the id in the body should be supported', async () => {
+      const original = await addUser(account, { firstName: 'firstName - test user' });
+      const user = await updateUser(account, original.data.id, { id: original.data.id, firstName: 'updated' });
+      expect(user.status).toBe(200);
+      expect(user.data.id).toBeDefined();
+      expect(user.data.firstName).toBe('updated');
+      expect(user.data.identities).toBeUndefined();
+      expect(user.data.access).toBeUndefined();
+      expect(user.data.id.indexOf('usr-')).toBe(0);
+    }, 20000);
+
+    test('Updating a user with an id in the body that does not match the url returns an error', async () => {
+      const original = await addUser(account, { firstName: 'firstName - test user' });
+      const id = 'usr-5555555555555555';
+      const user = await updateUser(account, original.data.id, { id, firstName: 'updated' });
+      expectMore(user).toBeHttpError(
+        400,
+        `The userId in the body '${id}' does not match the userId in the URL '${original.data.id}'`
+      );
+    }, 20000);
+
     test('Updating a user with an empty string first name is not supported', async () => {
       const original = await addUser(account, { firstName: 'firstName - test user' });
       const user = await updateUser(account, original.data.id, { firstName: '' });

--- a/lib/server/function-lambda/src/delete_function.js
+++ b/lib/server/function-lambda/src/delete_function.js
@@ -6,6 +6,9 @@ const create_error = require('http-errors');
 module.exports = function lambda_delete_function(req, res, next) {
   return module.exports.core(req.params, (e, r) => {
     if (e) {
+      if (e.code === 'ResourceNotFoundException') {
+        return next(create_error(404));
+      }
       return next(create_error(500, `Error deleting function: ${e.message}.`));
     }
     res.status(204);
@@ -69,6 +72,6 @@ function delete_user_function(options, cb) {
     {
       FunctionName: Common.get_user_function_name(options),
     },
-    e => (e && e.code !== 'ResourceNotFoundException' ? cb(e) : cb())
+    e => (e ? cb(e) : cb())
   );
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.10.11",
+  "version": "0.10.12",
   "private": true,
   "org": "5qtrs",
   "scripts": {


### PR DESCRIPTION
Fixes the two issues identified during API review:

- Allow UserId/IssuerId/ClientId in patch but verify it matches with url 
- Delete function should return 404 if the function does not exist
 