### PR TITLE
Final API fixes

### DIFF
--- a/api/function-api/api.yaml
+++ b/api/function-api/api.yaml
@@ -47,7 +47,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Account'
-        400: 
+        400:
           description: Malformed account id
           content:
             application/json:
@@ -101,7 +101,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SubscriptionList'
-        400: 
+        400:
           description: Malformed account id or invalid query
           content:
             application/json:
@@ -150,7 +150,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        400: 
+        400:
           description: Malformed account or subscription id
           content:
             application/json:
@@ -176,35 +176,69 @@ paths:
       - in: query
         name: resource
         required: false
-        description: Optional prefix of the resource to match against audit entries (case-sensitive)
+        description: |
+          Optional identifier to match against the 'resource' field of audit entries. 
+          Matching is case-sensitive. The resource in the audit entry must begin with the identifier to be considered a match.
+
+          Given an audit entry with a resource of '/account/acc-5555555555555555/subscription/sub-5555555555555555/', the
+          following queries would result in a match:
+            
+            - resource=/account/acc-
+            - resource=/account/acc-5555555555555555/subscription/
+            - resource=/account/acc-5555555555555555/subscription/sub-5555555555555555/
+
+          Given the same audit entry, the following queries would not result in a match:
+
+            - resource=acc-
+            - resource=account/acc-5555555555555555
+            - resource=subscription/sub-5555555555555555/
         schema:
           type: string
       - in: query
         name: action
         required: false
-        description: Optional action to match against audit entries (case-sensitive)
+        description: |
+          Optional identifier to match against the 'action' field of audit entries. Matching is case-sensitive. 
+          Both fully-qualified actions and wildcard actions are supported. 
+          Examples of fully-qualified actions include: 'user:get', 'function:put'. 
+          Examples of wildcard actions include: 'user:*', 'function:*'.
+
+          Given an audit entry with an action of 'function:put', the
+          following queries would result in a match:
+            
+            - action=function:*
+            - action=function:put
+
+          Given the same audit entry, the following query would not result in a match:
+
+            - action=function:get
         schema:
           type: string
       - in: query
         name: issuerId
         required: false
-        description: Optional issuer identifier to match against audit entries (case-sensitive)
+        description: |
+          Optional identifier to match against the 'issuerId' field of audit entries. 
+          Matching is case-sensitive. The full issuerId must be provided as partial matches are not supported.
         schema:
           $ref: '#/components/schemas/IssuerId'
       - in: query
         name: subject
         required: false
-        description: Optional subject identifier to match against audit entries (case-sensitive)
+        description: |
+          Optional identifier to match against the 'subject' filed of audit entries. 
+          Only valid if the 'issuerId' query filter is also provided.
+          Matching is case-sensitive. The full subject must be provided as partial matches are not supported.
         schema:
           type: string
       - in: query
         name: from
         required: false
         description: |
-        Optional time from which to return audit entries. Can be any format accepted by the JavaScript Date constructor
-        or a relative date of the format '-{integer}{s|m|h|d}', where 's' is seconds, 'm' is minutes, 'h' is hours and 'd' is days.
-        
-        All of the following are valid:
+          Optional time from which to return audit entries. Can be any format accepted by the JavaScript Date constructor
+          or a relative date of the format '-{integer}{s | m | h | d}', where 's' is seconds, 'm' is minutes, 'h' is hours and 'd' is days.
+
+          All of the following are valid queries:
           - from=1559605282105 (absolute time in milliseconds since 1 January 1970 UTC)
           - from=2019-06-03T23:42:16.976Z
           - from=Mon, 03 Jun 2019 23:42:30 GMT
@@ -218,10 +252,10 @@ paths:
         name: to
         required: false
         description: |
-        Optional time up to which to return audit entries. Can be any format accepted by the JavaScript Date constructor 
-        or a relative date of the format '-{integer}{s|m|h|d}', where 's' is seconds, 'm' is minutes, 'h' is hours and 'd' is days.
-        
-        All of the following are valid:
+          Optional time up to which to return audit entries. Can be any format accepted by the JavaScript Date constructor 
+          or a relative date of the format '-{integer}{s | m | h | d}', where 's' is seconds, 'm' is minutes, 'h' is hours and 'd' is days.
+
+          All of the following are valid queries:
           - from=1559605282105 (absolute time in milliseconds since 1 January 1970 UTC)
           - from=2019-06-03T23:42:16.976Z
           - from=Mon, 03 Jun 2019 23:42:30 GMT
@@ -232,19 +266,19 @@ paths:
         schema:
           type: string
       - in: query
-          name: next
-          required: false
-          description: Optional opaque token to start returning results from
-          schema:
-            type: string
+        name: next
+        required: false
+        description: Optional opaque token to start returning results from
+        schema:
+          type: string
       - in: query
-          name: count
-          required: false
-          description: Optional number of results to return
-          schema:
-            type: number
-            minimum: 1
-            maximum: 100
+        name: count
+        required: false
+        description: Optional number of results to return
+        schema:
+          type: number
+          minimum: 1
+          maximum: 100
     get:
       tags:
         - Accounts
@@ -255,7 +289,7 @@ paths:
         Each entry of the audit trail contains the timestamp of the call, resource, action, and the identity of 
         the caller represented as the (issuer, subject) pair. Use query string parameters to filter the entries. 
         All query filters are combined with a logical AND operator.
-        
+
         By default, only the most recent 15 minutes of audit logs are returned. You can change this with the 'from' query parameter.
       responses:
         200:
@@ -300,7 +334,9 @@ paths:
         - in: query
           name: name
           required: false
-          description: Optional name identifier to match against the displayName of the issuer (case-sensitive)
+          description: |
+            Optional identifier to match against the 'displayName' field of the issuer. Matching is case-sensitive. Partial
+            matches are supported.
           schema:
             type: string
         - in: query
@@ -367,7 +403,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Issuer'
-        400: 
+        400:
           description: Malformed account or issuer id
           content:
             application/json:
@@ -473,7 +509,7 @@ paths:
       responses:
         204:
           description: Issuer was deleted
-        400: 
+        400:
           description: Malformed account or issuer id
           content:
             application/json:
@@ -515,33 +551,36 @@ paths:
         - in: query
           name: include
           required: false
-          description: Optional switch to include all properties of the clients
+          description: |
+            Optional switch to include all properties of the clients in the response. If this switch is not provided only
+            the 'id' and 'displayName' fields of each client are returned in the response.
           schema:
             type: string
             enum:
               - all
         - in: query
-          name: exact
-          required: false
-          description: Optional switch to require all match identifiers to match exactly, instead of matching if value contains the identifier
-          schema:
-            type: boolean
-        - in: query
           name: name
           required: false
-          description: Optional name identifier to match against the displayName of the clients (case-sensitive)
+          description: |
+            Optional identifier to match against the 'displayName' field of the clients. Matching is case-sensitive. Partial
+            matches are supported.
           schema:
             type: string
         - in: query
           name: issuerId
           required: false
-          description: Optional issuerId identifier to match against the identities of the clients (case-sensitive)
+          description: |
+            Optional identifier to match against the 'issuerId' field of the identities of the clients. 
+            Matching is case-sensitive. The full issuerId must be provided as partial matches are not supported.
           schema:
             $ref: '#/components/schemas/IssuerId'
         - in: query
           name: subject
           required: false
-          description: Optional subject identifier to match against the identities of the clients (case-sensitive)
+          description: |
+            Optional identifier to match against the 'subject' field of the identities of the clients.
+            Only valid if the 'issuerId' query filter is also provided. Matching is case-sensitive. 
+            The full subject must be provided as partial matches are not supported.
           schema:
             type: string
         - in: query
@@ -644,7 +683,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Client'
-        400: 
+        400:
           description: Malformed account or client id
           content:
             application/json:
@@ -715,7 +754,7 @@ paths:
       responses:
         204:
           description: Client was deleted
-        400: 
+        400:
           description: Malformed account or client id
           content:
             application/json:
@@ -757,39 +796,44 @@ paths:
         - in: query
           name: include
           required: false
-          description: Optional switch to include all properties of the users
+          description: |
+            Optional switch to include all properties of the users in the response. If this switch is not provided only
+            the 'id' and 'firstName', 'lastName' and 'primaryEmail' fields of each user are returned in the response.
           schema:
             type: string
             enum:
               - all
         - in: query
-          name: exact
-          required: false
-          description: Optional switch to require all match identifiers to match exactly, instead of matching if value contains the identifier
-          schema:
-            type: boolean
-        - in: query
           name: name
           required: false
-          description: Optional name identifier to match against the firstName or LastName of the users (case-sensitive)
+          description: |
+            Optional identifier to match against the 'firstName' or 'LastName' fields of the users.
+            Matching is case-sensitive. Partial matches are supported.
           schema:
             type: string
         - in: query
           name: email
           required: false
-          description: Optional name identifier to match against the primaryEmail of the users (case-sensitive)
+          description: |
+            Optional identifier to match against the 'primaryEmail' field of the users. 
+            Matching is case-sensitive. Partial matches are supported.
           schema:
             type: string
         - in: query
           name: issuerId
           required: false
-          description: Optional issuerId identifier to match against the identities of the users (case-sensitive)
+          description: |
+            Optional identifier to match against the 'issuerId' field of the identities of the users. 
+            Matching is case-sensitive. The full issuerId must be provided as partial matches are not supported.
           schema:
-            type: string
+            $ref: '#/components/schemas/IssuerId'
         - in: query
           name: subject
           required: false
-          description: Optional subject identifier to match against the identities of the users (case-sensitive)
+          description: |
+            Optional identifier to match against the 'subject' field of the identities of the users.
+            Only valid if the 'issuerId' query filter is also provided. Matching is case-sensitive. 
+            The full subject must be provided as partial matches are not supported.
           schema:
             type: string
         - in: query
@@ -1024,7 +1068,11 @@ paths:
         - in: query
           name: cron
           required: false
-          description: If 'true' only functions with cron enabled will be returned. If 'false' only functions without cron enabled will be returned. If not specified, all functions will be returned.
+          description: |
+            Optional switch that determines whether to include or exclude functions that have cron enabled.
+            If 'true' only functions with cron enabled will be returned. 
+            If 'false' only functions without cron enabled will be returned. 
+            If not specified, all functions will be returned.
           schema:
             type: boolean
       responses:
@@ -1034,7 +1082,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FunctionList'
-        400: 
+        400:
           description: Malformed account or subscription id, or invalid query
           content:
             application/json:
@@ -1102,7 +1150,11 @@ paths:
         - in: query
           name: cron
           required: false
-          description: If 'true' only functions with cron enabled will be returned. If 'false' only functions without cron enabled will be returned. If not specified, all functions will be returned.
+          description: |
+            Optional switch that determines whether to include or exclude functions that have cron enabled.
+            If 'true' only functions with cron enabled will be returned. 
+            If 'false' only functions without cron enabled will be returned. 
+            If not specified, all functions will be returned.
           schema:
             type: boolean
       responses:
@@ -1112,7 +1164,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FunctionList'
-        400: 
+        400:
           description: Malformed account or subscription id, or invalid query
           content:
             application/json:
@@ -1156,14 +1208,16 @@ paths:
     get:
       tags:
         - Boundaries
-      summary: Get real-time logs of all functions executed within the given boundary with 'x-fx-logs=1' as a query parameter or http header
+      summary: |
+        Get real-time logs of all functions executed within the given boundary with 'x-fx-logs=1' as a query 
+        parameter or http header
       description: |
         Returns a text/event-stream response with streaming real-time logs generated by all functions executing in a boundary
       operationId: getBoundaryLogs
       responses:
         200:
           description: Stream of text/event-stream log data
-        400: 
+        400:
           description: Malformed account, subscription or boundary id
           content:
             application/json:
@@ -1224,7 +1278,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Function'
-        400: 
+        400:
           description: Malformed account, subscription, boundary or function id
           content:
             application/json:
@@ -1249,7 +1303,11 @@ paths:
         - Functions
       summary: Initiate a new build and deployment of a function
       description: |
-        Initiates a build and deployment of the function within the isolation boundary. This may complete synchronously with a status code of 200, or asynchronously with a status code of 201. If it completes asynchronously, it returns immediately with a response that includes a 'buildId' representing the function build process. This 'buildId' can be used to poll for completion by calling 'GET /build/{buildId}'.
+        Initiates a build and deployment of the function within the isolation boundary. 
+        This may complete synchronously with a status code of 200, or asynchronously with a status code of 201. 
+        If it completes asynchronously, it returns immediately with a response that includes a 'buildId' 
+        representing the function build process. This 'buildId' can be used to poll for completion by calling 
+        'GET /build/{buildId}'.
 
         The URL for executing the function will be provided as the 'location' property of the response.
       operationId: putFunction
@@ -1275,7 +1333,7 @@ paths:
                 $ref: '#/components/schemas/Build'
         204:
           description: No change to function
-        400: 
+        400:
           description: Malformed account, subscription, boundary or function id, or invalid function
           content:
             application/json:
@@ -1312,7 +1370,7 @@ paths:
       responses:
         204:
           description: Function was deleted
-        400: 
+        400:
           description: Malformed account, subscription, boundary or function id
           content:
             application/json:
@@ -1369,7 +1427,7 @@ paths:
       responses:
         200:
           description: Stream of text/event-stream log data
-        400: 
+        400:
           description: Malformed account, subscription, boundary or function id
           content:
             application/json:
@@ -1430,7 +1488,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FunctionLocation'
-        400: 
+        400:
           description: Malformed account, subscription, boundary or function id
           content:
             application/json:
@@ -1488,7 +1546,10 @@ paths:
         - Functions
       summary: Get the status of a build of a function
       description: |
-        Returns the status of the build of a function. This is used for polling the result of the asynchronous build process of a function. The 'status' parameter progressess from 'pending' to 'building' to either 'success' or 'failure', which are the final states of the build process.
+        Returns the status of the build of a function. This is used for polling the result of 
+        the asynchronous build process of a function. The 'status' parameter progressess from 
+        'pending' to 'building' to either 'success' or 'failure', which are the final states 
+        of the build process.
       operationId: getFunctionBuild
       responses:
         200:
@@ -1503,7 +1564,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Build'
-        400: 
+        400:
           description: Malformed account, subscription, boundary, function or build id, or invalid function
           content:
             application/json:
@@ -1626,8 +1687,8 @@ components:
           description: Identifier of the user, unique within the issuer
           example: google-oauth2|skjdhfsadhfalkajsdhf
         authorized:
-            type: boolean
-            description: If 'true' the action was authorized; if 'false' the action was not authorized and was not allowed to continue
+          type: boolean
+          description: If 'true' the action was authorized; if 'false' the action was not authorized and was not allowed to continue
 
     SubscriptionId:
       type: string
@@ -1753,7 +1814,7 @@ components:
       type: string
       description: Client id
       example: 'clt-5555555555555555'
-    
+
     NewClient:
       type: object
       properties:
@@ -1781,7 +1842,7 @@ components:
             id:
               $ref: '#/components/schemas/ClientId'
         - $ref: '#/components/schemas/NewClient'
-    
+
     ClientList:
       type: object
       required:
@@ -1836,7 +1897,7 @@ components:
             id:
               $ref: '#/components/schemas/UserId'
         - $ref: '#/components/schemas/NewUser'
-    
+
     UserList:
       type: object
       required:

--- a/api/function-api/src/routes/handlers/audit.js
+++ b/api/function-api/src/routes/handlers/audit.js
@@ -7,8 +7,8 @@ function auditGet() {
       const accountId = req.params.accountId;
       const limit = req.query.count;
       const next = req.query.next;
-      const actionContains = req.query.action;
-      const resourceStartsWith = req.query.resource;
+      const action = req.query.action;
+      const resource = req.query.resource;
       const issuerId = req.query.issuerId;
       const subject = req.query.subject;
       const from = req.query.from;
@@ -16,8 +16,8 @@ function auditGet() {
       const options = {
         limit,
         next,
-        actionContains,
-        resourceStartsWith,
+        action,
+        resource,
         issuerId,
         subject,
         from,

--- a/api/function-api/src/routes/handlers/client.js
+++ b/api/function-api/src/routes/handlers/client.js
@@ -64,18 +64,17 @@ function clientList() {
       const limit = req.query.count;
       const next = req.query.next;
       const displayNameContains = req.query.name;
-      const issuerContains = req.query.issuerId;
-      const subjectContains = req.query.subject;
+      const issuerId = req.query.issuerId;
+      const subject = req.query.subject;
       const include = req.query.include;
-      const exact = req.query.exact === 'true' || req.query.exact == 1 ? true : false;
       const options = {
         limit,
         next,
         include,
         exact,
         displayNameContains,
-        issuerContains,
-        subjectContains,
+        issuerId,
+        subject,
       };
 
       accountContext.client

--- a/api/function-api/src/routes/handlers/user.js
+++ b/api/function-api/src/routes/handlers/user.js
@@ -65,19 +65,17 @@ function userList() {
       const next = req.query.next;
       const nameContains = req.query.name;
       const primaryEmailContains = req.query.email;
-      const issuerContains = req.query.issuerId;
-      const subjectContains = req.query.subject;
+      const issuerId = req.query.issuerId;
+      const subject = req.query.subject;
       const include = req.query.include;
-      const exact = req.query.exact === 'true' || req.query.exact == 1 ? true : false;
       const options = {
         limit,
         next,
         include,
-        exact,
         nameContains,
         primaryEmailContains,
-        issuerContains,
-        subjectContains,
+        issuerId,
+        subject,
       };
 
       accountContext.user

--- a/api/function-api/src/routes/schemas/api_query.js
+++ b/api/function-api/src/routes/schemas/api_query.js
@@ -8,7 +8,6 @@ module.exports = Joi.object().keys({
   issuerId: Joi.string(),
   subject: Joi.string(),
   include: Joi.string().valid('all'),
-  exact: Joi.string().valid('true', 'false', '1', '0'),
   cron: Joi.string().valid('true', 'false', '1', '0'),
   action: Joi.string(),
   resource: Joi.string(),

--- a/api/function-api/src/routes/v1_api.js
+++ b/api/function-api/src/routes/v1_api.js
@@ -404,7 +404,7 @@ router.get(
   cors(corsManagementOptions),
   validate_schema({ params: require('./schemas/api_account') }),
   authorize({
-    operation: 'function:list',
+    operation: 'function:get',
   }),
   validate_schema({
     query: require('./schemas/api_query'),

--- a/api/function-api/test/client.list.test.ts
+++ b/api/function-api/test/client.list.test.ts
@@ -96,69 +96,12 @@ describe('Client', () => {
       }
     }, 50000);
 
-    test('Listing all clients filtered by issuerId should return only filtered clients', async () => {
-      await Promise.all([
-        addClient(account, { identities: [{ issuerId: `${testRunId} - 6a`, subject: `sub-${random()}` }] }),
-        addClient(account, { identities: [{ issuerId: `${testRunId} - 6b`, subject: `sub-${random()}` }] }),
-        addClient(account, { identities: [{ issuerId: `${testRunId} - 6c`, subject: `sub-${random()}` }] }),
-        addClient(account, { identities: [{ issuerId: `${testRunId} - 6d`, subject: `sub-${random()}` }] }),
-        addClient(account, { identities: [{ issuerId: `${testRunId} - 6e`, subject: `sub-${random()}` }] }),
-      ]);
-      const result = await listClients(account, { issuerId: `${testRunId} - 6`, include: true });
-      expect(result.status).toBe(200);
-      expect(result.data.items.length).toBe(5);
-      const lookup: any = {};
-
-      for (const item of result.data.items) {
-        expect(lookup[item.id]).toBeUndefined();
-        lookup[item.id] = item;
-        expect(item.identities[0].issuerId.indexOf(`${testRunId} - 6`)).toBe(0);
-      }
-    }, 50000);
-
-    test('Listing all clients filtered by subject should return only filtered clients', async () => {
-      await Promise.all([
-        addClient(account, { identities: [{ subject: `${testRunId} - 7a`, issuerId: `foo` }] }),
-        addClient(account, { identities: [{ subject: `${testRunId} - 7b`, issuerId: `foo` }] }),
-        addClient(account, { identities: [{ subject: `${testRunId} - 7c`, issuerId: `foo` }] }),
-        addClient(account, { identities: [{ subject: `${testRunId} - 7d`, issuerId: `foo` }] }),
-        addClient(account, { identities: [{ subject: `${testRunId} - 7e`, issuerId: `foo` }] }),
-      ]);
-      const result = await listClients(account, { subject: `${testRunId} - 7`, include: true });
-      expect(result.status).toBe(200);
-      expect(result.data.items.length).toBe(5);
-      const lookup: any = {};
-
-      for (const item of result.data.items) {
-        expect(lookup[item.id]).toBeUndefined();
-        lookup[item.id] = item;
-        expect(item.identities[0].subject.indexOf(`${testRunId} - 7`)).toBe(0);
-      }
-    }, 50000);
-
-    test('Listing all clients filtered by display name should return only exact matches if exact=true', async () => {
-      await Promise.all([
-        addClient(account, { displayName: `${testRunId} - 8` }),
-        addClient(account, { displayName: `${testRunId} - 8a` }),
-      ]);
-      const result = await listClients(account, { name: `${testRunId} - 8`, exact: true });
-      expect(result.status).toBe(200);
-      expect(result.data.items.length).toBe(1);
-      const lookup: any = {};
-
-      for (const item of result.data.items) {
-        expect(lookup[item.id]).toBeUndefined();
-        lookup[item.id] = item;
-        expect(item.displayName).toBe(`${testRunId} - 8`);
-      }
-    }, 50000);
-
-    test('Listing all clients filtered by issuerId should return only exact matches if exact=true', async () => {
+    test('Listing all clients filtered by issuerId should return only exact matches', async () => {
       await Promise.all([
         addClient(account, { identities: [{ issuerId: `${testRunId} - 11`, subject: `sub-${random()}` }] }),
         addClient(account, { identities: [{ issuerId: `${testRunId} - 11a`, subject: `sub-${random()}` }] }),
       ]);
-      const result = await listClients(account, { issuerId: `${testRunId} - 11`, include: true, exact: true });
+      const result = await listClients(account, { issuerId: `${testRunId} - 11`, include: true });
       expect(result.status).toBe(200);
       expect(result.data.items.length).toBe(1);
       const lookup: any = {};
@@ -170,24 +113,7 @@ describe('Client', () => {
       }
     }, 50000);
 
-    test('Listing all clients filtered by subject should return only exact matches if exact=true', async () => {
-      await Promise.all([
-        addClient(account, { identities: [{ subject: `${testRunId} - 12`, issuerId: `foo` }] }),
-        addClient(account, { identities: [{ subject: `${testRunId} - 12a`, issuerId: `foo` }] }),
-      ]);
-      const result = await listClients(account, { subject: `${testRunId} - 12`, include: true, exact: true });
-      expect(result.status).toBe(200);
-      expect(result.data.items.length).toBe(1);
-      const lookup: any = {};
-
-      for (const item of result.data.items) {
-        expect(lookup[item.id]).toBeUndefined();
-        lookup[item.id] = item;
-        expect(item.identities[0].subject).toBe(`${testRunId} - 12`);
-      }
-    }, 50000);
-
-    test('Listing all clients filtered by issuerId and subject should return only exact matches if exact=true', async () => {
+    test('Listing all clients filtered by issuerId and subject should return only exact matches', async () => {
       await Promise.all([
         addClient(account, { identities: [{ subject: `${testRunId} - 12`, issuerId: `foo` }] }),
         addClient(account, { identities: [{ subject: `${testRunId} - 12a`, issuerId: `foo` }] }),
@@ -198,7 +124,6 @@ describe('Client', () => {
         subject: `${testRunId} - 12`,
         issuerId: 'foo',
         include: true,
-        exact: true,
       });
       expect(result.status).toBe(200);
       expect(result.data.items.length).toBe(1);
@@ -282,6 +207,18 @@ describe('Client', () => {
         lookup[item.id] = item;
         expect(item.displayName.indexOf(`${testRunId} - 15`)).toBe(0);
       }
+    }, 50000);
+
+    test('Listing all clients filtered by subject without issuerId should return an error', async () => {
+      await Promise.all([
+        addClient(account, { identities: [{ subject: `${testRunId} - 7`, issuerId: `foo` }] }),
+        addClient(account, { identities: [{ subject: `${testRunId} - 7`, issuerId: `foo2` }] }),
+      ]);
+      const result = await listClients(account, { subject: `${testRunId} - 7`, include: true });
+      expectMore(result).toBeHttpError(
+        400,
+        `The 'subject' filter '${testRunId} - 7' can not be specified without the 'issuerId' filter`
+      );
     }, 50000);
 
     test('Listing clients with a malformed account should return an error', async () => {

--- a/api/function-api/test/user.list.test.ts
+++ b/api/function-api/test/user.list.test.ts
@@ -54,7 +54,7 @@ describe('User', () => {
       }
     }, 50000);
 
-    test('Listing all users does return identities and access by default if include=all', async () => {
+    test('Listing all users does return identities and access if include=all', async () => {
       const access = { allow: [{ action: 'user:*', resource: '/account/abc/' }] };
       const firstName = `first - ${testRunId}`;
       await Promise.all([
@@ -181,103 +181,12 @@ describe('User', () => {
       }
     }, 50000);
 
-    test('Listing all users filtered by issuerId should return only filtered users', async () => {
-      await Promise.all([
-        addUser(account, { identities: [{ issuerId: `${testRunId} - 6a`, subject: `sub-${random()}` }] }),
-        addUser(account, { identities: [{ issuerId: `${testRunId} - 6b`, subject: `sub-${random()}` }] }),
-        addUser(account, { identities: [{ issuerId: `${testRunId} - 6c`, subject: `sub-${random()}` }] }),
-        addUser(account, { identities: [{ issuerId: `${testRunId} - 6d`, subject: `sub-${random()}` }] }),
-        addUser(account, { identities: [{ issuerId: `${testRunId} - 6e`, subject: `sub-${random()}` }] }),
-      ]);
-      const result = await listUsers(account, { issuerId: `${testRunId} - 6`, include: true });
-      expect(result.status).toBe(200);
-      expect(result.data.items.length).toBe(5);
-      const lookup: any = {};
-
-      for (const item of result.data.items) {
-        expect(lookup[item.id]).toBeUndefined();
-        lookup[item.id] = item;
-        expect(item.identities[0].issuerId.indexOf(`${testRunId} - 6`)).toBe(0);
-      }
-    }, 50000);
-
-    test('Listing all users filtered by subject should return only filtered users', async () => {
-      await Promise.all([
-        addUser(account, { identities: [{ subject: `${testRunId} - 7a`, issuerId: `foo` }] }),
-        addUser(account, { identities: [{ subject: `${testRunId} - 7b`, issuerId: `foo` }] }),
-        addUser(account, { identities: [{ subject: `${testRunId} - 7c`, issuerId: `foo` }] }),
-        addUser(account, { identities: [{ subject: `${testRunId} - 7d`, issuerId: `foo` }] }),
-        addUser(account, { identities: [{ subject: `${testRunId} - 7e`, issuerId: `foo` }] }),
-      ]);
-      const result = await listUsers(account, { subject: `${testRunId} - 7`, include: true });
-      expect(result.status).toBe(200);
-      expect(result.data.items.length).toBe(5);
-      const lookup: any = {};
-
-      for (const item of result.data.items) {
-        expect(lookup[item.id]).toBeUndefined();
-        lookup[item.id] = item;
-        expect(item.identities[0].subject.indexOf(`${testRunId} - 7`)).toBe(0);
-      }
-    }, 50000);
-
-    test('Listing all users filtered by first name should return only exact matches if exact=true', async () => {
-      await Promise.all([
-        addUser(account, { firstName: `${testRunId} - 8` }),
-        addUser(account, { firstName: `${testRunId} - 8a` }),
-      ]);
-      const result = await listUsers(account, { name: `${testRunId} - 8`, exact: true });
-      expect(result.status).toBe(200);
-      expect(result.data.items.length).toBe(1);
-      const lookup: any = {};
-
-      for (const item of result.data.items) {
-        expect(lookup[item.id]).toBeUndefined();
-        lookup[item.id] = item;
-        expect(item.firstName).toBe(`${testRunId} - 8`);
-      }
-    }, 50000);
-
-    test('Listing all users filtered by last name should return only exact matches if exact=true', async () => {
-      await Promise.all([
-        addUser(account, { lastName: `${testRunId} - 9` }),
-        addUser(account, { lastName: `${testRunId} - 9a` }),
-      ]);
-      const result = await listUsers(account, { name: `${testRunId} - 9`, exact: true });
-      expect(result.status).toBe(200);
-      expect(result.data.items.length).toBe(1);
-      const lookup: any = {};
-
-      for (const item of result.data.items) {
-        expect(lookup[item.id]).toBeUndefined();
-        lookup[item.id] = item;
-        expect(item.lastName).toBe(`${testRunId} - 9`);
-      }
-    }, 50000);
-
-    test('Listing all users filtered by email should return only exact matches if exact=true', async () => {
-      await Promise.all([
-        addUser(account, { primaryEmail: `${testRunId} - 10` }),
-        addUser(account, { primaryEmail: `${testRunId} - 10a` }),
-      ]);
-      const result = await listUsers(account, { email: `${testRunId} - 10`, exact: true });
-      expect(result.status).toBe(200);
-      expect(result.data.items.length).toBe(1);
-      const lookup: any = {};
-
-      for (const item of result.data.items) {
-        expect(lookup[item.id]).toBeUndefined();
-        lookup[item.id] = item;
-        expect(item.primaryEmail).toBe(`${testRunId} - 10`);
-      }
-    }, 50000);
-
-    test('Listing all users filtered by issuerId should return only exact matches if exact=true', async () => {
+    test('Listing all users filtered by issuerId should return only exact matches', async () => {
       await Promise.all([
         addUser(account, { identities: [{ issuerId: `${testRunId} - 11`, subject: `sub-${random()}` }] }),
         addUser(account, { identities: [{ issuerId: `${testRunId} - 11a`, subject: `sub-${random()}` }] }),
       ]);
-      const result = await listUsers(account, { issuerId: `${testRunId} - 11`, include: true, exact: true });
+      const result = await listUsers(account, { issuerId: `${testRunId} - 11`, include: true });
       expect(result.status).toBe(200);
       expect(result.data.items.length).toBe(1);
       const lookup: any = {};
@@ -289,24 +198,7 @@ describe('User', () => {
       }
     }, 50000);
 
-    test('Listing all users filtered by subject should return only exact matches if exact=true', async () => {
-      await Promise.all([
-        addUser(account, { identities: [{ subject: `${testRunId} - 12`, issuerId: `foo` }] }),
-        addUser(account, { identities: [{ subject: `${testRunId} - 12a`, issuerId: `foo` }] }),
-      ]);
-      const result = await listUsers(account, { subject: `${testRunId} - 12`, include: true, exact: true });
-      expect(result.status).toBe(200);
-      expect(result.data.items.length).toBe(1);
-      const lookup: any = {};
-
-      for (const item of result.data.items) {
-        expect(lookup[item.id]).toBeUndefined();
-        lookup[item.id] = item;
-        expect(item.identities[0].subject).toBe(`${testRunId} - 12`);
-      }
-    }, 50000);
-
-    test('Listing all users filtered by issuerId and subject should return only exact matches if exact=true', async () => {
+    test('Listing all users filtered by issuerId and subject should return only exact matches', async () => {
       await Promise.all([
         addUser(account, { identities: [{ subject: `${testRunId} - 12`, issuerId: `foo` }] }),
         addUser(account, { identities: [{ subject: `${testRunId} - 12a`, issuerId: `foo` }] }),
@@ -317,7 +209,6 @@ describe('User', () => {
         subject: `${testRunId} - 12`,
         issuerId: 'foo',
         include: true,
-        exact: true,
       });
       expect(result.status).toBe(200);
       expect(result.data.items.length).toBe(1);
@@ -401,6 +292,18 @@ describe('User', () => {
         lookup[item.id] = item;
         expect(item.lastName.indexOf(`${testRunId} - 15`)).toBe(0);
       }
+    }, 50000);
+
+    test('Listing all users filtered by subject without issuerId should return an error', async () => {
+      await Promise.all([
+        addUser(account, { identities: [{ subject: `${testRunId} - 7`, issuerId: `foo` }] }),
+        addUser(account, { identities: [{ subject: `${testRunId} - 7`, issuerId: `foo2` }] }),
+      ]);
+      const result = await listUsers(account, { subject: `${testRunId} - 7`, include: true });
+      expectMore(result).toBeHttpError(
+        400,
+        `The 'subject' filter '${testRunId} - 7' can not be specified without the 'issuerId' filter`
+      );
     }, 50000);
 
     test('Listing users with a malformed account should return an error', async () => {

--- a/lib/data/account-data-aws/src/AgentData.ts
+++ b/lib/data/account-data-aws/src/AgentData.ts
@@ -226,10 +226,7 @@ export class AgentData extends DataSource implements IAgentData {
   private async deleteCliIdentityIssuer(accountId: string, agentId: string, identity: IIdentity): Promise<void> {
     const issuerId = identity.issuerId;
     if (isCliIssuer(issuerId, agentId)) {
-      const remainingIdentities = await this.identityTable.list(accountId, {
-        issuerContains: issuerId,
-        exact: true,
-      });
+      const remainingIdentities = await this.identityTable.list(accountId, { issuerId: issuerId });
       if (remainingIdentities.items.length === 0) {
         await this.issuerTable.delete(accountId, issuerId);
       }

--- a/lib/data/account-data-aws/src/ClientData.ts
+++ b/lib/data/account-data-aws/src/ClientData.ts
@@ -81,10 +81,10 @@ export class ClientData extends DataSource implements IClientData {
 
   public async list(accountId: string, options?: IListClientsOptions): Promise<IListClientsResult> {
     if (options) {
-      if (options.issuerContains && options.subjectContains) {
+      if (options.issuerId && options.subject) {
         return this.tryGetIssuerSubject(accountId, options);
       }
-      if (options.issuerContains || options.subjectContains) {
+      if (options.issuerId || options.subject) {
         return this.listIssuerSubject(accountId, options);
       }
     }
@@ -114,8 +114,8 @@ export class ClientData extends DataSource implements IClientData {
 
   private async tryGetIssuerSubject(accountId: string, options: IListClientsOptions): Promise<IListClientsResult> {
     const identity = {
-      issuerId: options.issuerContains as string,
-      subject: options.subjectContains as string,
+      issuerId: options.issuerId as string,
+      subject: options.subject as string,
     };
 
     let agent;
@@ -128,7 +128,7 @@ export class ClientData extends DataSource implements IClientData {
     }
 
     if (!agent) {
-      return this.listIssuerSubject(accountId, options);
+      return { items: [] };
     }
 
     const agentId = agent.id as string;
@@ -166,8 +166,8 @@ export class ClientData extends DataSource implements IClientData {
       limit,
     };
     const agentOptions = {
-      issuerContains: options.issuerContains,
-      subjectContains: options.subjectContains,
+      issuerId: options.issuerId,
+      subject: options.subject,
       next: options.next,
       limit,
     };

--- a/lib/data/account-data-aws/src/UserData.ts
+++ b/lib/data/account-data-aws/src/UserData.ts
@@ -82,10 +82,10 @@ export class UserData extends DataSource implements IUserData {
 
   public async list(accountId: string, options?: IListUsersOptions): Promise<IListUsersResult> {
     if (options) {
-      if (options.issuerContains && options.subjectContains) {
+      if (options.issuerId && options.subject) {
         return this.tryGetIssuerSubject(accountId, options);
       }
-      if (options.issuerContains || options.subjectContains) {
+      if (options.issuerId || options.subject) {
         return this.listIssuerSubject(accountId, options);
       }
     }
@@ -114,8 +114,8 @@ export class UserData extends DataSource implements IUserData {
 
   private async tryGetIssuerSubject(accountId: string, options: IListUsersOptions): Promise<IListUsersResult> {
     const identity = {
-      issuerId: options.issuerContains as string,
-      subject: options.subjectContains as string,
+      issuerId: options.issuerId as string,
+      subject: options.subject as string,
     };
 
     let agent;
@@ -128,7 +128,7 @@ export class UserData extends DataSource implements IUserData {
     }
 
     if (!agent) {
-      return options.exact ? { items: [] } : this.listIssuerSubject(accountId, options);
+      return { items: [] };
     }
 
     const agentId = agent.id as string;
@@ -163,14 +163,12 @@ export class UserData extends DataSource implements IUserData {
     const usersOptions = {
       primaryEmailContains: options.primaryEmailContains,
       nameContains: options.nameContains,
-      exact: options.exact,
       next: options.next,
       limit: options.limit,
     };
     const agentOptions = {
-      issuerContains: options.issuerContains,
-      subjectContains: options.subjectContains,
-      exact: options.exact,
+      issuerId: options.issuerId,
+      subject: options.subject,
       next: options.next,
       limit: options.limit,
     };

--- a/lib/data/account-data-aws/src/tables/AuditEntryTable.ts
+++ b/lib/data/account-data-aws/src/tables/AuditEntryTable.ts
@@ -105,8 +105,8 @@ export interface IListAuditEntriesOptions {
   limit?: number;
   from?: Date;
   to?: Date;
-  resourceStartsWith?: string;
-  actionContains?: string;
+  resource?: string;
+  action?: string;
   issuerId?: string;
   subject?: string;
 }
@@ -156,11 +156,11 @@ export class AuditEntryTable extends AwsDynamoTable {
         keyConditions.push('begins_with(#identity, :identity)');
         expressionNames['#identity'] = 'identity';
         expressionValues[':identity'] = identity;
-      } else if (options.resourceStartsWith) {
+      } else if (options.resource) {
         resourceFilter = false;
         keyConditions.push('begins_with(#resource, :resource)');
         expressionNames['#resource'] = 'resource';
-        expressionValues[':resource'] = { S: options.resourceStartsWith };
+        expressionValues[':resource'] = { S: options.resource };
       } else if (options.from || options.to) {
         index = timestampIndex;
         timeStampFilter = false;
@@ -187,16 +187,16 @@ export class AuditEntryTable extends AwsDynamoTable {
         }
       }
 
-      if (options.actionContains) {
+      if (options.action) {
         filters.push('begins_with(#action, :action)');
         expressionNames['#action'] = 'action';
-        expressionValues[':action'] = { S: options.actionContains };
+        expressionValues[':action'] = { S: options.action };
       }
 
-      if (options.resourceStartsWith && resourceFilter) {
+      if (options.resource && resourceFilter) {
         filters.push('begins_with(#resource, :resource)');
         expressionNames['#resource'] = 'resource';
-        expressionValues[':resource'] = { S: options.resourceStartsWith };
+        expressionValues[':resource'] = { S: options.resource };
       }
     }
 

--- a/lib/data/account-data-aws/src/tables/IdentityTable.ts
+++ b/lib/data/account-data-aws/src/tables/IdentityTable.ts
@@ -97,9 +97,8 @@ export interface IListIdentitiesOptions {
   next?: string;
   limit?: number;
   agentId?: string;
-  issuerContains?: string;
-  subjectContains?: string;
-  exact?: boolean;
+  issuerId?: string;
+  subject?: string;
 }
 
 export interface IListIdentitiesResult {
@@ -138,7 +137,6 @@ export class IdentityTable extends AwsDynamoTable {
     const filters = [];
     const keyConditions = ['accountId = :accountId'];
     const expressionValues: any = { ':accountId': { S: accountId } };
-    const exact = options && options.exact === true;
 
     if (options) {
       if (options.agentId) {
@@ -147,14 +145,14 @@ export class IdentityTable extends AwsDynamoTable {
         keyConditions.push('agentId = :agentId');
       }
 
-      if (options.issuerContains) {
-        filters.push(exact ? 'issuerId = :issuerId' : 'contains(issuerId, :issuerId)');
-        expressionValues[':issuerId'] = { S: options.issuerContains };
+      if (options.issuerId) {
+        filters.push('issuerId = :issuerId');
+        expressionValues[':issuerId'] = { S: options.issuerId };
       }
 
-      if (options.subjectContains) {
-        filters.push(exact ? 'subject = :subject' : 'contains(subject, :subject)');
-        expressionValues[':subject'] = { S: options.subjectContains };
+      if (options.subject) {
+        filters.push('subject = :subject');
+        expressionValues[':subject'] = { S: options.subject };
       }
     }
 

--- a/lib/data/account-data/src/AccountDataException.ts
+++ b/lib/data/account-data/src/AccountDataException.ts
@@ -30,6 +30,7 @@ export enum AccountDataExceptionCode {
   invalidFilterDate = 'invalidFilterDate',
   invalidFilterDateOrder = 'invalidFilterDateOrder',
   invalidFilterIdentity = 'invalidFilterIdentity',
+  invalidFilterAction = 'invalidFilterAction',
   issuerTooManyKeys = 'issuerTooManyKeys',
   issuerEmptyPublicKeys = 'issuerEmptyPublicKeys',
   issuerMissingKeyId = 'issuerMissingKeyId',
@@ -164,6 +165,11 @@ export class AccountDataException extends Exception {
   public static invalidFilterIdentity(subject: string) {
     const message = `The 'subject' filter '${subject}' can not be specified without the 'issuerId' filter`;
     return new AccountDataException(AccountDataExceptionCode.invalidFilterIdentity, message, [subject]);
+  }
+
+  public static invalidFilterAction(action: string) {
+    const message = `The 'action' filter '${action}' is invalid`;
+    return new AccountDataException(AccountDataExceptionCode.invalidFilterIdentity, message, [action]);
   }
 
   public static noPublicKey(keyId: string) {

--- a/lib/data/account-data/src/IAuditData.ts
+++ b/lib/data/account-data/src/IAuditData.ts
@@ -20,8 +20,8 @@ export interface IListAuditEntriesOptions {
   limit?: number;
   from?: Date;
   to?: Date;
-  resourceStartsWith?: string;
-  actionContains?: string;
+  resource?: string;
+  action?: string;
   issuerId?: string;
   subject?: string;
 }

--- a/lib/data/account-data/src/IClientData.ts
+++ b/lib/data/account-data/src/IClientData.ts
@@ -17,10 +17,9 @@ export interface IListClientsOptions {
   next?: string;
   limit?: number;
   include?: ClientInclude;
-  exact?: boolean;
   displayNameContains?: string;
-  issuerContains?: string;
-  subjectContains?: string;
+  issuerId?: string;
+  subject?: string;
 }
 
 export interface IListClientsResult {

--- a/lib/data/account-data/src/IUserData.ts
+++ b/lib/data/account-data/src/IUserData.ts
@@ -20,11 +20,10 @@ export interface IListUsersOptions {
   next?: string;
   limit?: number;
   include?: UserInclude;
-  exact?: boolean;
   nameContains?: string;
   primaryEmailContains?: string;
-  issuerContains?: string;
-  subjectContains?: string;
+  issuerId?: string;
+  subject?: string;
 }
 
 export interface IListUsersResult {

--- a/lib/server/account/src/Client.ts
+++ b/lib/server/account/src/Client.ts
@@ -73,6 +73,9 @@ export class Client {
     accountId: string,
     options?: IListClientsOptions
   ): Promise<IListClientsResult> {
+    if (options && options.subject && !options.issuerId) {
+      throw AccountDataException.invalidFilterIdentity(options.subject);
+    }
     const accountPromise = this.dataContext.accountData.get(accountId);
     const clientPromise = this.dataContext.clientData.list(accountId, options);
     return cancelOnError(accountPromise, clientPromise);

--- a/lib/server/account/src/User.ts
+++ b/lib/server/account/src/User.ts
@@ -73,6 +73,9 @@ export class User {
     accountId: string,
     options?: IListUsersOptions
   ): Promise<IListUsersResult> {
+    if (options && options.subject && !options.issuerId) {
+      throw AccountDataException.invalidFilterIdentity(options.subject);
+    }
     const accountPromise = this.dataContext.accountData.get(accountId);
     const userPromise = this.dataContext.userData.list(accountId, options);
     return cancelOnError(accountPromise, userPromise);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.10.12",
+  "version": "0.10.13",
   "private": true,
   "org": "5qtrs",
   "scripts": {


### PR DESCRIPTION
Fixes: 

- Investigate making issuer and client consistent across audit and user client search
- Audit: `action` needs to be `domain:*` or `domain:action`
- Make sure we document which query params are starts-with vs exact match. Document which ones need to be used in pairs
