### PR TITLE
Fusebit CLI fixes

### DIFF
--- a/cli/fusebit-cli/package.json
+++ b/cli/fusebit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/fusebit-cli",
-  "version": "0.0.10",
+  "version": "0.0.6",
   "description": "",
   "main": "libc/index.js",
   "bin": {

--- a/cli/fusebit-cli/src/FusebitCli.ts
+++ b/cli/fusebit-cli/src/FusebitCli.ts
@@ -1,4 +1,5 @@
-import { Command, ICommand, ArgType } from '@5qtrs/cli';
+import { Command, ICommand, IExecuteInput, ArgType } from '@5qtrs/cli';
+import { Text } from '@5qtrs/text';
 import {
   ClientCommand,
   FunctionCommand,
@@ -59,5 +60,33 @@ export class FusebitCli extends Command {
   public static async create() {
     cli.subCommands = await getSubCommands();
     return new FusebitCli(cli);
+  }
+
+  protected async onSubCommandError(command: Command, input: IExecuteInput, error: Error) {
+    const verbose = input.options.verbose as boolean;
+    if (verbose) {
+      try {
+        input.io.writeRaw(
+          Text.create(
+            Text.red('[ Unhandled Error ] ').bold(),
+            Text.eol(),
+            Text.eol(),
+            Text.bold('Message'),
+            Text.eol(),
+            error.message,
+            Text.eol(),
+            Text.eol(),
+            Text.bold('Stack Trace'),
+            Text.eol(),
+            error.stack || '<No Stack Trace>',
+            Text.eol(),
+            Text.eol()
+          )
+        );
+      } catch (__) {
+        console.log(error);
+      }
+    }
+    return 1;
   }
 }

--- a/cli/fusebit-cli/src/services/UserService.ts
+++ b/cli/fusebit-cli/src/services/UserService.ts
@@ -406,7 +406,9 @@ export class UserService {
     let decoded;
     try {
       decoded = await decodeJwt(token);
-    } catch (error) {
+    } catch (__) {}
+
+    if (!decoded) {
       this.executeService.error('Init Error', 'The init token is not a valid Json Web Token (JWT)');
       throw new Error('Init Error');
     }
@@ -444,8 +446,8 @@ export class UserService {
       boundaryId: decoded.boundaryId,
       functionId: decoded.functionId,
       baseUrl: decoded.baseUrl,
-      issuerId: decoded.iss,
-      subject: decoded.sub,
+      issuerId: decoded.issuerId,
+      subject: decoded.subject,
     };
   }
 


### PR DESCRIPTION
- Fixes the "truncated init token" bug that we ran into with Uplevel on boarding due to Google Hangout Chat truncating messages

- Adds the support for `--verbose (-v)` which now works for all commands and will print the unhandled exception and its stack trace to allow us to more quickly debug issues