### PR TITLE
test improvements

### DIFF
--- a/api/function-api/src/index.ts
+++ b/api/function-api/src/index.ts
@@ -9,6 +9,7 @@ app.set('port', normalizedPort);
 
 const server = http.createServer(app);
 server.listen(normalizedPort);
+server.keepAliveTimeout = 130 * 1000;
 server.on('error', onError);
 server.on('listening', onListening);
 

--- a/api/function-api/test/authorization.test.ts
+++ b/api/function-api/test/authorization.test.ts
@@ -58,14 +58,14 @@ let account: IAccount = FakeAccount;
 beforeAll(async () => {
   account = await resolveAccount();
   testIssuer = await createTestJwksIssuer(account);
-}, 10000);
+}, 50000);
 
 afterAll(async () => {
   await cleanUpHostedIssuers(account);
   await cleanUpUsers(account);
   await cleanUpClients(account);
   await cleanUpStorage(account);
-}, 20000);
+}, 100000);
 
 describe('Authorization', () => {
   test('A user without access should not be authorized to do anything', async () => {
@@ -79,8 +79,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -124,8 +124,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(clientAccount, 'boundary', 'function', {}),
       getFunction(clientAccount, 'boundary', 'function'),
-      getLogs(clientAccount, 'boundary'),
-      getLogs(clientAccount, 'boundary', 'function'),
+      getLogs(clientAccount, 'boundary', undefined, true),
+      getLogs(clientAccount, 'boundary', 'function', true),
       getFunctionLocation(clientAccount, 'boundary', 'function'),
       deleteFunction(clientAccount, 'boundary', 'function'),
       listFunctions(clientAccount),
@@ -184,8 +184,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, boundaryId, functionId, {}),
       getFunction(userAccount, boundaryId, 'another-function'),
-      getLogs(userAccount, boundaryId),
-      getLogs(userAccount, boundaryId, functionId),
+      getLogs(userAccount, boundaryId, undefined, true),
+      getLogs(userAccount, boundaryId, functionId, true),
       getFunctionLocation(userAccount, boundaryId, 'another-function'),
       deleteFunction(userAccount, boundaryId, functionId),
       listFunctions(userAccount),
@@ -250,8 +250,8 @@ describe('Authorization', () => {
 
     const results = await Promise.all([
       putFunction(userAccount, boundaryId, functionId, {}),
-      getLogs(userAccount, boundaryId),
-      getLogs(userAccount, boundaryId, functionId),
+      getLogs(userAccount, boundaryId, undefined, true),
+      getLogs(userAccount, boundaryId, functionId, true),
       deleteFunction(userAccount, boundaryId, functionId),
       listFunctions(userAccount),
       listFunctions(userAccount, 'another-boundary'),
@@ -317,8 +317,8 @@ describe('Authorization', () => {
 
     const results = await Promise.all([
       putFunction(userAccount, boundaryId, functionId, {}),
-      getLogs(userAccount, boundaryId),
-      getLogs(userAccount, boundaryId, functionId),
+      getLogs(userAccount, boundaryId, undefined, true),
+      getLogs(userAccount, boundaryId, functionId, true),
       deleteFunction(userAccount, boundaryId, functionId),
       addIssuer(userAccount, 'test-issuer', {}),
       listIssuers(userAccount),
@@ -373,8 +373,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, boundaryId, 'another-function', {}),
       getFunction(userAccount, boundaryId, functionId),
-      getLogs(userAccount, boundaryId),
-      getLogs(userAccount, boundaryId, functionId),
+      getLogs(userAccount, boundaryId, undefined, true),
+      getLogs(userAccount, boundaryId, functionId, true),
       getFunctionLocation(userAccount, boundaryId, functionId),
       deleteFunction(userAccount, boundaryId, functionId),
       listFunctions(userAccount),
@@ -432,8 +432,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'another-boundary', functionId, {}),
       getFunction(userAccount, boundaryId, functionId),
-      getLogs(userAccount, boundaryId),
-      getLogs(userAccount, boundaryId, functionId),
+      getLogs(userAccount, boundaryId, undefined, true),
+      getLogs(userAccount, boundaryId, functionId, true),
       getFunctionLocation(userAccount, boundaryId, functionId),
       deleteFunction(userAccount, boundaryId, functionId),
       listFunctions(userAccount),
@@ -499,8 +499,8 @@ describe('Authorization', () => {
 
     const results = await Promise.all([
       getFunction(userAccount, boundaryId, functionId),
-      getLogs(userAccount, boundaryId),
-      getLogs(userAccount, boundaryId, functionId),
+      getLogs(userAccount, boundaryId, undefined, true),
+      getLogs(userAccount, boundaryId, functionId, true),
       getFunctionLocation(userAccount, boundaryId, functionId),
       deleteFunction(userAccount, boundaryId, functionId),
       listFunctions(userAccount),
@@ -555,8 +555,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, boundaryId, functionId, {}),
       getFunction(userAccount, boundaryId, functionId),
-      getLogs(userAccount, boundaryId),
-      getLogs(userAccount, boundaryId, functionId),
+      getLogs(userAccount, boundaryId, undefined, true),
+      getLogs(userAccount, boundaryId, functionId, true),
       getFunctionLocation(userAccount, boundaryId, functionId),
       listFunctions(userAccount),
       listFunctions(userAccount, boundaryId),
@@ -612,8 +612,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, boundaryId, functionId, {}),
       getFunction(userAccount, boundaryId, functionId),
-      getLogs(userAccount, boundaryId),
-      getLogs(userAccount, boundaryId, functionId),
+      getLogs(userAccount, boundaryId, undefined, true),
+      getLogs(userAccount, boundaryId, functionId, true),
       getFunctionLocation(userAccount, boundaryId, functionId),
       deleteFunction(userAccount, 'another-boundary', functionId),
       listFunctions(userAccount),
@@ -667,8 +667,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, boundaryId, functionId, {}),
       getFunction(userAccount, boundaryId, functionId),
-      getLogs(userAccount, boundaryId),
-      getLogs(userAccount, boundaryId, functionId),
+      getLogs(userAccount, boundaryId, undefined, true),
+      getLogs(userAccount, boundaryId, functionId, true),
       getFunctionLocation(userAccount, boundaryId, functionId),
       listFunctions(userAccount),
       listFunctions(userAccount, boundaryId),
@@ -722,8 +722,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, boundaryId, functionId, {}),
       getFunction(userAccount, boundaryId, functionId),
-      getLogs(userAccount, boundaryId),
-      getLogs(userAccount, boundaryId, 'another-function'),
+      getLogs(userAccount, boundaryId, undefined, true),
+      getLogs(userAccount, boundaryId, 'another-function', true),
       deleteFunction(userAccount, boundaryId, functionId),
       getFunctionLocation(userAccount, boundaryId, functionId),
       listFunctions(userAccount),
@@ -905,7 +905,7 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, boundaryId, 'another-function', {}),
       getFunction(userAccount, boundaryId, 'another-function'),
-      getLogs(userAccount, boundaryId, 'another-function'),
+      getLogs(userAccount, boundaryId, 'another-function', true),
       deleteFunction(userAccount, boundaryId, 'another-function'),
       getFunctionLocation(userAccount, boundaryId, 'another-function'),
       listFunctions(userAccount),
@@ -975,8 +975,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'another-boundary', functionId, {}),
       getFunction(userAccount, 'another-boundary', functionId),
-      getLogs(userAccount, 'another-boundary'),
-      getLogs(userAccount, 'another-boundary', functionId),
+      getLogs(userAccount, 'another-boundary', undefined, true),
+      getLogs(userAccount, 'another-boundary', functionId, true),
       deleteFunction(userAccount, 'another-boundary', functionId),
       getFunctionLocation(userAccount, 'another-boundary', functionId),
       listFunctions(userAccount, 'another-boundary'),
@@ -1088,8 +1088,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -1141,8 +1141,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -1192,8 +1192,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -1250,8 +1250,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -1300,8 +1300,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -1352,8 +1352,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -1403,8 +1403,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -1456,8 +1456,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -1516,8 +1516,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -1580,8 +1580,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -1627,8 +1627,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -1740,8 +1740,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -1801,8 +1801,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -1854,8 +1854,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -1910,8 +1910,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -2026,8 +2026,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -2083,8 +2083,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -2138,8 +2138,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -2196,8 +2196,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -2259,8 +2259,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -2322,8 +2322,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -2368,8 +2368,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -2481,8 +2481,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -2542,8 +2542,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -2595,8 +2595,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -2651,8 +2651,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -2767,8 +2767,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -2824,8 +2824,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -2879,8 +2879,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -2937,8 +2937,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -3001,8 +3001,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -3068,8 +3068,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -3126,8 +3126,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -3180,8 +3180,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -3233,8 +3233,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -3287,8 +3287,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -3347,8 +3347,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -3403,8 +3403,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -3457,8 +3457,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -3512,8 +3512,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -3573,8 +3573,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -3634,8 +3634,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -3689,8 +3689,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),
@@ -3745,8 +3745,8 @@ describe('Authorization', () => {
     const results = await Promise.all([
       putFunction(userAccount, 'boundary', 'function', {}),
       getFunction(userAccount, 'boundary', 'function'),
-      getLogs(userAccount, 'boundary'),
-      getLogs(userAccount, 'boundary', 'function'),
+      getLogs(userAccount, 'boundary', undefined, true),
+      getLogs(userAccount, 'boundary', 'function', true),
       getFunctionLocation(userAccount, 'boundary', 'function'),
       deleteFunction(userAccount, 'boundary', 'function'),
       listFunctions(userAccount),

--- a/api/function-api/test/cron.test.ts
+++ b/api/function-api/test/cron.test.ts
@@ -14,16 +14,15 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await deleteAllFunctions(account, boundaryId);
-});
+}, 20000);
 
 beforeEach(async () => {
   await deleteAllFunctions(account, boundaryId);
-});
+}, 20000);
 
 describe('cron', () => {
-
   test('cron executes on schedule', async () => {
-    // Create a "storage" function. Total hack. 
+    // Create a "storage" function. Total hack.
 
     let runs = Buffer.from(JSON.stringify([]), 'utf8').toString('base64');
     let response = await putFunction(account, boundaryId, function2Id, {
@@ -33,11 +32,11 @@ describe('cron', () => {
         },
       },
       configuration: {
-        runs
-      }
+        runs,
+      },
     });
     expect(response.status).toEqual(200);
-   
+
     // Create cron that re-creates the storage function every second with a timestamp of its execution
 
     response = await putFunction(account, boundaryId, function1Id, {
@@ -64,7 +63,7 @@ describe('cron', () => {
           'config.json': {
             account,
             boundaryId,
-            functionId: function2Id
+            functionId: function2Id,
           },
           'package.json': {
             dependencies: {

--- a/api/function-api/test/execution.test.ts
+++ b/api/function-api/test/execution.test.ts
@@ -1,7 +1,6 @@
 import { IAccount, FakeAccount, resolveAccount } from './accountResolver';
 import { putFunction, deleteAllFunctions, waitForBuild } from './sdk';
 import { request } from '@5qtrs/request';
-import { string } from 'prop-types';
 
 let account: IAccount = FakeAccount;
 
@@ -14,11 +13,11 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await deleteAllFunctions(account, boundaryId);
-});
+}, 200000);
 
 beforeEach(async () => {
   await deleteAllFunctions(account, boundaryId);
-});
+}, 200000);
 
 describe('execution', () => {
   test('hello, world succeeds on node 8', async () => {
@@ -40,7 +39,7 @@ describe('execution', () => {
     expect(response.status).toEqual(200);
     expect(response.data).toEqual('hello');
     expect(response.headers['x-fx-response-source']).toEqual('function');
-  });
+  }, 10000);
 
   test('hello, world succeeds on node 10', async () => {
     let response = await putFunction(account, boundaryId, function1Id, {
@@ -61,7 +60,7 @@ describe('execution', () => {
     expect(response.status).toEqual(200);
     expect(response.data).toEqual('hello');
     expect(response.headers['x-fx-response-source']).toEqual('function');
-  });
+  }, 10000);
 
   test('function with module succeeds on node 8', async () => {
     let response = await putFunction(account, boundaryId, function1Id, {
@@ -170,7 +169,7 @@ describe('execution', () => {
     expect(response.status).toEqual(418);
     expect(response.data).toEqual('teapot');
     expect(response.headers['x-fx-response-source']).toEqual('function');
-  });
+  }, 10000);
 
   test('function can set response headers', async () => {
     let response = await putFunction(account, boundaryId, function1Id, {
@@ -188,7 +187,7 @@ describe('execution', () => {
     expect(response.headers.foo).toEqual('abc');
     expect(response.headers.bar).toEqual('def');
     expect(response.headers['x-fx-response-source']).toEqual('function');
-  });
+  }, 10000);
 
   test('function without response payload returns empty response', async () => {
     let response = await putFunction(account, boundaryId, function1Id, {
@@ -204,7 +203,7 @@ describe('execution', () => {
     expect(response.status).toEqual(200);
     expect(response.data).toEqual(undefined);
     expect(response.headers['x-fx-response-source']).toEqual('function');
-  });
+  }, 10000);
 
   test('function with empty response payload returns empty response', async () => {
     let response = await putFunction(account, boundaryId, function1Id, {
@@ -220,7 +219,7 @@ describe('execution', () => {
     expect(response.status).toEqual(200);
     expect(response.data).toEqual(undefined);
     expect(response.headers['x-fx-response-source']).toEqual('function');
-  });
+  }, 10000);
 
   test('function with module dependency can load the module', async () => {
     let response = await putFunction(account, boundaryId, function1Id, {
@@ -301,7 +300,7 @@ describe('execution', () => {
         // stackTrace: expect.any(Array),
       },
     });
-  });
+  }, 10000);
 
   test('function with synchronous exception fails', async () => {
     let response = await putFunction(account, boundaryId, function1Id, {
@@ -326,7 +325,7 @@ describe('execution', () => {
         // stackTrace: expect.any(Array),
       },
     });
-  });
+  }, 10000);
 
   test('function with callback exception fails', async () => {
     let response = await putFunction(account, boundaryId, function1Id, {
@@ -351,7 +350,7 @@ describe('execution', () => {
         // stackTrace: expect.any(Array),
       },
     });
-  });
+  }, 10000);
 
   test('function with async exception fails', async () => {
     let response = await putFunction(account, boundaryId, function1Id, {
@@ -382,7 +381,7 @@ describe('execution', () => {
         errorMessage: expect.stringMatching(/Process exited before completing request/),
       },
     });
-  });
+  }, 10000);
 
   test('function with wrong signature fails', async () => {
     let response = await putFunction(account, boundaryId, function1Id, {
@@ -407,5 +406,5 @@ describe('execution', () => {
         // stackTrace: expect.any(Array),
       },
     });
-  });
+  }, 10000);
 });

--- a/api/function-api/test/issuer.update.test.ts
+++ b/api/function-api/test/issuer.update.test.ts
@@ -128,7 +128,7 @@ describe('Issuer', () => {
       expect(issuer.data.id).toBe(issuerId);
     }, 10000);
 
-    test.only('Updating an issuer with an id in the body that does not match the url returns an error', async () => {
+    test('Updating an issuer with an id in the body that does not match the url returns an error', async () => {
       const issuerId = `test-${random()}`;
       await addIssuer(account, issuerId, { jsonKeysUrl: 'foo' });
       const id = 'other-issuer-id';

--- a/api/function-api/test/log.test.ts
+++ b/api/function-api/test/log.test.ts
@@ -1,14 +1,5 @@
 import { IAccount, FakeAccount, resolveAccount } from './accountResolver';
-import {
-  deleteFunction,
-  putFunction,
-  getFunction,
-  listFunctions,
-  deleteAllFunctions,
-  getFunctionLocation,
-  sleep,
-  getLogs,
-} from './sdk';
+import { putFunction, deleteAllFunctions, getLogs } from './sdk';
 import { request } from '@5qtrs/request';
 
 let account: IAccount = FakeAccount;
@@ -16,31 +7,22 @@ let account: IAccount = FakeAccount;
 let boundaryId = `test-boundary-${Math.floor(Math.random() * 99999999).toString(32)}`;
 const function1Id = 'test-function-1';
 
-const helloWorld = {
-  nodejs: {
-    files: {
-      'index.js': 'module.exports = (ctx, cb) => cb(null, { body: "hello" });',
-    },
-  },
-};
-
 beforeAll(async () => {
   account = await resolveAccount();
 });
 
 afterAll(async () => {
   await deleteAllFunctions(account, boundaryId);
-});
+}, 20000);
 
 beforeEach(async () => {
   boundaryId = `test-boundary-${Math.floor(Math.random() * 99999999).toString(32)}`;
   // await deleteAllFunctions(account, boundaryId);
-});
+}, 20000);
 
 afterEach(async () => {
-  // boundaryId = `test-boundary-${Math.floor(Math.random() * 99999999).toString(32)}`;
   await deleteAllFunctions(account, boundaryId);
-});
+}, 20000);
 
 describe('log', () => {
   function create_positive_log_test(node: string, query: boolean, boundary: boolean) {
@@ -64,6 +46,8 @@ describe('log', () => {
 
       const functionUrl = response.data.location;
       const logsPromise = getLogs(account, boundaryId, boundary ? undefined : function1Id);
+
+      await new Promise(resolve => setTimeout(resolve, 250));
 
       if (query) {
         for (var i = 1; i < 5; i++) {

--- a/api/function-api/test/module.test.ts
+++ b/api/function-api/test/module.test.ts
@@ -28,11 +28,11 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await deleteAllFunctions(account, boundaryId);
-});
+}, 20000);
 
 beforeEach(async () => {
   await deleteAllFunctions(account, boundaryId);
-});
+}, 20000);
 
 describe('module', () => {
   test('PUT completes for function with superagent dependency', async () => {
@@ -67,7 +67,7 @@ describe('module', () => {
     response = await putFunction(account, boundaryId, function1Id, helloWorldWithSuperagentDependency);
     expect(response.status).toEqual(200);
     expect(response.data.status).toEqual('success');
-  }, 15000);
+  }, 20000);
 
   test('PUT completes for function with complex dependencies', async () => {
     let response = await putFunction(account, boundaryId, function1Id, {

--- a/api/function-api/test/sdk.ts
+++ b/api/function-api/test/sdk.ts
@@ -190,8 +190,9 @@ export async function getLogs(
       bufferedResponse.headers = response.headers;
       bufferedResponse.data = '';
 
-      if (ignoreLogs) {
+      if (ignoreLogs && bufferedResponse.status === 200) {
         onDone();
+        return;
       }
 
       response.on('data', (data: string) => (bufferedResponse.data += data.toString()));
@@ -201,7 +202,7 @@ export async function getLogs(
     logRequest = http.get(url, { headers, agent: false }, onResponse);
 
     if (!ignoreLogs) {
-      timer = setTimeout(onDone, 5000);
+      timer = setTimeout(onDone, 10000);
     }
   });
 }

--- a/lib/shared/request/package.json
+++ b/lib/shared/request/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "",
   "main": "libc/index.js",
-  "browser": "libm/index.js",
+  "browser": "libm/browser.js",
   "module": "libm/index.js",
   "sideEffects": false,
   "license": "UNLICENSED",

--- a/lib/shared/request/src/browser.ts
+++ b/lib/shared/request/src/browser.ts
@@ -1,0 +1,7 @@
+import { request as core, IHttpRequest, IHttpResponse } from './request';
+
+export async function request(urlOrRequest: string | IHttpRequest): Promise<IHttpResponse> {
+  return core(urlOrRequest, undefined, undefined);
+}
+
+export { IHttpRequest, IHttpResponse };

--- a/lib/shared/request/src/index.ts
+++ b/lib/shared/request/src/index.ts
@@ -1,1 +1,12 @@
-export { request, IHttpRequest, IHttpResponse } from './request';
+import http from 'http';
+import https from 'https';
+import { request as core, IHttpRequest, IHttpResponse } from './request';
+
+const httpAgent = new http.Agent({ keepAlive: true });
+const httpsAgent = new https.Agent({ keepAlive: true });
+
+export async function request(urlOrRequest: string | IHttpRequest): Promise<IHttpResponse> {
+  return core(urlOrRequest, httpAgent, httpsAgent);
+}
+
+export { IHttpRequest, IHttpResponse };

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.11.5",
+  "version": "0.11.6",
   "private": true,
   "org": "5qtrs",
   "scripts": {


### PR DESCRIPTION
- Use keep-alive in the request package to improve perf calling the API during test run
- Increase keep-alive timeout on server to 130 seconds (ELB idle timeout is 120 seconds) to avoid the server terminating a connection that the ELB is waiting on
- Increase individual test timeouts
- Fix for the code around getting 403 when calling `get logs` with the auth tests