### PR TITLE
Fusebit-ops-cli and HTML enablement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ typings/
 .aws.*.env.bak
 
 .DS_Store
+.tgz

--- a/api/function-api/src/routes/account.js
+++ b/api/function-api/src/routes/account.js
@@ -33,7 +33,8 @@ async function getAccountContext() {
 
 async function getResolvedAgent(accountId, token) {
   const accountContext = await getAccountContext();
-  const isRootAgent = token === process.env.API_AUTHORIZATION_KEY;
+  // Disallow the configuration of a trusted symmetric key
+  const isRootAgent = false; // token === process.env.API_AUTHORIZATION_KEY;
   return accountContext.getResolvedAgent(accountId, token, isRootAgent);
 }
 

--- a/cli/fusebit-ops-cli/package.json
+++ b/cli/fusebit-ops-cli/package.json
@@ -1,13 +1,16 @@
 {
   "name": "@5qtrs/fusebit-ops-cli",
-  "version": "0.0.1",
-  "description": "",
+  "version": "1.12.0",
+  "description": "The Fusebit Platform Operations CLI",
   "main": "libc/index.js",
   "license": "UNLICENSED",
-  "author": "FiveQuarters.io",
+  "author": "https://fusebit.io",
   "bin": {
     "fuse-ops": "libc/index.js"
   },
+  "private": true,
+  "packageAs": "fusebit-ops-cli",
+  "packageAssets": [],
   "scripts": {
     "build": "tsc -b",
     "test": "jest --colors",

--- a/cli/fusebit-ops-cli/src/commands/stack/ListStackCommand.ts
+++ b/cli/fusebit-ops-cli/src/commands/stack/ListStackCommand.ts
@@ -1,5 +1,5 @@
 import { Command, IExecuteInput } from '@5qtrs/cli';
-import { StackService } from '../../services';
+import { StackService, DeploymentService } from '../../services';
 
 // ------------------
 // Internal Constants
@@ -44,10 +44,12 @@ export class ListStackCommand extends Command {
     const format = input.options.format as string;
 
     const stackService = await StackService.create(input);
+    const deploymentService = await DeploymentService.create(input);
+    const deployments = await deploymentService.listAllDeployments();
 
     if (format === 'json') {
       const stacks = await stackService.listAllStacks(deploymentName);
-      await stackService.displayStacks(stacks);
+      await stackService.displayStacks(stacks, deployments);
     } else {
       let getMore = true;
       let result;
@@ -55,7 +57,7 @@ export class ListStackCommand extends Command {
       while (getMore) {
         result = await stackService.listStacks(options);
         options.next = result.next || undefined;
-        await stackService.displayStacks(result.items);
+        await stackService.displayStacks(result.items, deployments);
         getMore = result.next ? await stackService.confirmListMore() : false;
       }
     }

--- a/cli/fusebit-ops-cli/src/services/DeploymentService.ts
+++ b/cli/fusebit-ops-cli/src/services/DeploymentService.ts
@@ -419,6 +419,9 @@ export class DeploymentService {
       Text.eol(),
       Text.dim('Data Warehouse: '),
       deployment.dataWarehouseEnabled ? 'Enabled' : 'Disabled',
+      Text.eol(),
+      Text.dim('Base URL: '),
+      `https://${deployment.deploymentName}.${deployment.region}.${deployment.domainName}`,
     ];
 
     await this.executeService.message(Text.bold(deployment.deploymentName), Text.create(details));

--- a/lib/aws/aws-ecr/src/AwsEcr.ts
+++ b/lib/aws/aws-ecr/src/AwsEcr.ts
@@ -59,12 +59,12 @@ export class AwsEcr extends AwsBase<typeof ECR> {
     const decoded = fromBase64(auth.token);
     const token = decoded.substring(4);
     const command = [
-      `docker login -u AWS -p ${token} ${auth.loginUrl} &&`,
+      `docker login -u AWS --password-stdin ${auth.loginUrl} &&`,
       `docker pull ${accountId}.dkr.ecr.${region}.amazonaws.com/${repository}:${tag} &&`,
       `docker tag ${accountId}.dkr.ecr.${region}.amazonaws.com/${repository}:${tag} ${repository}:${tag}`,
     ].join(' ');
 
-    const result = await spawn(command, { shell: true });
+    const result = await spawn(command, { shell: true, stdin: token });
     if (result.code !== 0) {
       const message = `Docker login and pull failed with output: ${result.stderr.toString()}`;
       throw new Error(message);
@@ -86,12 +86,12 @@ export class AwsEcr extends AwsBase<typeof ECR> {
     const decoded = fromBase64(auth.token);
     const token = decoded.substring(4);
     const command = [
-      `docker login -u AWS -p ${token} ${auth.loginUrl} &&`,
+      `docker login -u AWS --password-stdin ${auth.loginUrl} &&`,
       `docker tag ${repository}:${tag} ${accountId}.dkr.ecr.${region}.amazonaws.com/${repository}:${tag} &&`,
       `docker push ${accountId}.dkr.ecr.${region}.amazonaws.com/${repository}:${tag}`,
     ].join(' ');
 
-    const result = await spawn(command, { shell: true });
+    const result = await spawn(command, { shell: true, stdin: token });
     if (result.code !== 0) {
       const message = `Docker login and push failed with output: ${result.stderr.toString()}`;
       throw new Error(message);

--- a/lib/aws/aws-route53/src/AwsRoute53.ts
+++ b/lib/aws/aws-route53/src/AwsRoute53.ts
@@ -16,6 +16,7 @@ function getMatchingDetail(
   details: IHostedZoneRecordDetail[]
 ): IHostedZoneRecordDetail | undefined {
   const name = normalizeDomain(record.name);
+  const aliasName = record.alias ? normalizeDomain(record.alias.name) : undefined;
   const values = record.values ? ensureArray(record.values) : undefined;
 
   for (const detail of details) {
@@ -24,7 +25,7 @@ function getMatchingDetail(
         record.alias &&
         detail.alias &&
         detail.alias.hostedZone === record.alias.hostedZone &&
-        detail.alias.name === record.alias.name
+        detail.alias.name === aliasName
       ) {
         return detail;
       } else if (values && detail.values && same(values, detail.values)) {

--- a/lib/data/ops-data/src/IOpsStackData.ts
+++ b/lib/data/ops-data/src/IOpsStackData.ts
@@ -9,6 +9,7 @@ export interface IOpsNewStack {
   region: string;
   tag: string;
   size?: number;
+  env?: string;
 }
 
 export interface IOpsStack extends IOpsNewStack {

--- a/lib/node/child-process/src/spawn.ts
+++ b/lib/node/child-process/src/spawn.ts
@@ -19,7 +19,7 @@ export default function spawn(
     cwd?: string;
     args?: string[];
     env?: {};
-    stdin?: Readable;
+    stdin?: string;
     stdout?: Writable;
     stderr?: Writable;
     shell?: boolean;
@@ -45,6 +45,10 @@ export default function spawn(
     }
 
     const child = childProcess.spawn(command, options.args || [], spawnOptions);
+    if (options.stdin) {
+      child.stdin.write(options.stdin);
+      child.stdin.end();
+    }
     process.on('beforeExit', () => {
       child.kill();
     });

--- a/lib/server/function-lambda/src/execute_function.js
+++ b/lib/server/function-lambda/src/execute_function.js
@@ -101,7 +101,15 @@ module.exports = function lambda_execute_function(req, res, next) {
             res.set(h, r.Payload.headers[h]);
           }
         }
-        r.Payload.body ? res.json(r.Payload.body) : res.end();
+        if (r.Payload.body) {
+          if (r.Payload.rawBody) {
+            res.send(r.Payload.body);
+          } else {
+            res.json(r.Payload.body);
+          }
+        } else {
+          res.end();
+        }
       } else {
         res.status(200);
         res.end();

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.11.10",
+  "version": "1.12.0",
   "private": true,
   "org": "5qtrs",
   "scripts": {


### PR DESCRIPTION
fusebit-ops-cli:

* Prepare fusebit-ops-cli for packgaging including private dependencies and publication on CDN
* Allow specification of a .env file on `fuse-ops stack add --env {file} ...`
* Automatically generate LOGS_TOKEN_SIGNATURE_KEY on `fuse-ops stack add`, allows overriding via .env
* Support for waiting for stack health up to 5 minutes in `fuse-ops stack add`
* Display base URL for stacks in `fuse-ops stack ls`
* Display base URL for deployment in `fuse-ops deployment ls`
* Avoid a security warning in `fuse-ops pull` by passing password through stdin
* Fix bug in removing Route53 entry on `fuse-ops stack rm`
* Change the stack ID to be a randomly generated integer 0-999 to reduce risk of cached DNS entries

Runtime:

* Disable support for API_AUTHORIZATION_KEY flat symmetric key - all API calls must use properly issued, trusted JWT tokens
* Support for returning any content type from Fusebit functions with `cb(null, { body: ..., rawBody: true })`