### PR TITLE
ops cli: support for specifying custom AMIs

### DIFF
--- a/api/function-api/src/routes/v1_api.js
+++ b/api/function-api/src/routes/v1_api.js
@@ -457,7 +457,7 @@ router.put(
   authorize({
     operation: 'function:put',
   }),
-  express.json(),
+  express.json({ limit: process.env.FUNCTION_SIZE_LIMIT || '100kb' }),
   validate_schema({
     body: require('./schemas/function_specification'),
     params: require('./schemas/api_params'),

--- a/cli/fusebit-ops-cli/package.json
+++ b/cli/fusebit-ops-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/fusebit-ops-cli",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "The Fusebit Platform Operations CLI",
   "main": "libc/index.js",
   "license": "UNLICENSED",

--- a/cli/fusebit-ops-cli/src/commands/stack/AddStackCommand.ts
+++ b/cli/fusebit-ops-cli/src/commands/stack/AddStackCommand.ts
@@ -37,6 +37,10 @@ const command = {
       description: 'Path to an .env file with additional environment variables for the stack',
     },
     {
+      name: 'ami',
+      description: 'AMI ID to use instead of the official Ubuntu AMI',
+    },
+    {
       name: 'confirm',
       aliases: ['c'],
       description: 'If set to true, prompts for confirmation before deploying the stack',
@@ -67,6 +71,7 @@ export class AddStackCommand extends Command {
     const size = input.options.size as number;
     const confirm = input.options.confirm as boolean;
     const env = input.options.env as string;
+    const ami = input.options.ami as string;
 
     const stackService = await StackService.create(input);
     const deploymentService = await DeploymentService.create(input);
@@ -78,6 +83,7 @@ export class AddStackCommand extends Command {
       size: size || deployment.size,
       region: deployment.region,
       env,
+      ami,
     };
 
     if (confirm) {

--- a/cli/fusebit-ops-cli/src/services/StackService.ts
+++ b/cli/fusebit-ops-cli/src/services/StackService.ts
@@ -32,8 +32,9 @@ export class StackService {
       details: [
         { name: 'Deployment', value: stack.deploymentName },
         { name: 'Tag', value: stack.tag },
-        { name: 'Size', value: stack.size ? stack.size.toString() : '<default>' },
+        { name: 'Size', value: stack.size ? stack.size.toString() : '<Default>' },
         { name: 'Environment', value: stack.env || '<Not set>' },
+        { name: 'AMI', value: stack.ami || '<Official Ubuntu AMI>' },
       ],
     });
     const confirmed = await confirmPrompt.prompt(this.input.io);

--- a/docs/fusebit-ops-cli.md
+++ b/docs/fusebit-ops-cli.md
@@ -12,9 +12,16 @@ The Fusebit operations CLI enables customers to create a private deployment of t
 
 All public releases of the Fusebit Operations CLI are documented here, including notable changes made in every release. CLI releases follow the [Semantic Versioning 2.0 specification](https://semver.org/). For more information on the Fusebit versioning strategy, see [here](http://fusebit.io/docs/integrator-guide/versioning).
 
-<!-- prettier-ignore -->
+<!-- prettier-ignore
 1. TOC
 {:toc}
+-->
+
+## Version 1.14.0
+
+_Released 10/14/19_
+
+- **Support for custom AMIs.** The `fuse-ops stack add` command now allows the specification of a custom AMI ID to use instead of the official Ubuntu AMI.
 
 ## Version 1.13.0
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,13 +29,13 @@ Fusebit Editor <code>v1.1+</code> - <a href="{{ site.baseurl }}{% link fusebit-e
 Fusebit HTTP API <code>v1.13+</code> - <a href="{{ site.baseurl }}{% link fusebit-http-api.md %}">release notes</a>
 </li>
 <li>
-Fusebit Ops CLI <code>v1.13+</code> - <a href="{{ site.baseurl }}{% link fusebit-ops-cli.md %}">release notes</a></li>
+Fusebit Ops CLI <code>v1.14+</code> - <a href="{{ site.baseurl }}{% link fusebit-ops-cli.md %}">release notes</a></li>
 </ul>
 </td>
 <td style="width:30%">
 <dl>
   <dt>Last updated</dt>
-  <dd>10/3/19</dd>
+  <dd>10/14/19</dd>
   <dt>LTS release</dt>
   <dd>No</dd>
 </dl>

--- a/lib/data/ops-data-aws/src/OpsStackData.ts
+++ b/lib/data/ops-data-aws/src/OpsStackData.ts
@@ -82,7 +82,7 @@ export class OpsStackData extends DataSource implements IOpsStackData {
     const id = await this.getNextStackId(newStack.deploymentName);
 
     const awsAmi = await AwsAmi.create(awsConfig);
-    const ami = await awsAmi.getUbuntuServerAmi(this.config.ubuntuServerVersion);
+    const amiId = newStack.ami || (await awsAmi.getUbuntuServerAmi(this.config.ubuntuServerVersion)).id;
 
     const awsAutoScale = await AwsAutoScale.create(awsConfig);
     const account = await this.accountData.get(network.accountName);
@@ -111,7 +111,7 @@ export class OpsStackData extends DataSource implements IOpsStackData {
     const autoScaleName = this.getAutoScaleName(id);
     await awsAutoScale.createAutoScale({
       name: autoScaleName,
-      amiId: ami.id,
+      amiId,
       instanceType: this.config.monoInstanceType,
       securityGroups: [network.securityGroupId],
       userData,

--- a/lib/data/ops-data/src/IOpsStackData.ts
+++ b/lib/data/ops-data/src/IOpsStackData.ts
@@ -10,6 +10,7 @@ export interface IOpsNewStack {
   tag: string;
   size?: number;
   env?: string;
+  ami?: string;
 }
 
 export interface IOpsStack extends IOpsNewStack {


### PR DESCRIPTION
fusebit-ops-cli 1.14.0:

* Support for specifying custom AWS AMI ID in `fuse-ops stack add` to use instead of the official Ubuntu one

fusebit-api: 

* Ability to override the default 100kb function size limit via the `FUNCTION_SIZE_LIMIT` environment variable