### PR TITLE
Fix paging through data when secondary indexes are used

### DIFF
--- a/api/function-api/test/sdk.ts
+++ b/api/function-api/test/sdk.ts
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 import { IAccount } from './accountResolver';
 import { request } from '@5qtrs/request';
 import { random } from '@5qtrs/random';
@@ -92,6 +94,18 @@ export interface ITestIssuer {
   jsonKeysUrl: string;
   keys: IKeyPair[];
   getAccessToken: (index: number, subject: string) => Promise<string>;
+}
+
+// ------------------
+// Internal Functions
+// ------------------
+
+function ngrok_url(url: string) {
+  // If running tests against local functions-api, replace the issuer JWKS endpoint to use Ngrok URL
+  if (url.indexOf('://localhost') > 0 && process.env.LOGS_HOST && process.env.API_SERVER) {
+    return url.replace(process.env.API_SERVER, `https://${process.env.LOGS_HOST}`);
+  }
+  return url;
 }
 
 // ------------------
@@ -676,7 +690,6 @@ export async function listAudit(account: IAccount, options?: IListAuditOptions) 
     }
   }
   const queryString = queryStringParams.length ? `?${queryStringParams.join('&')}` : '';
-
   return request({
     method: 'GET',
     headers: {
@@ -840,6 +853,9 @@ export async function hostIssuer(account: IAccount, issuerId: string, keys: any)
   }
 
   testHostedIssuers.push(issuerId);
+
+  result.data.location = ngrok_url(result.data.location);
+
   return result.data.location;
 }
 

--- a/docs/fusebit-http-api.md
+++ b/docs/fusebit-http-api.md
@@ -16,6 +16,12 @@ All public releases of the Fusebit HTTP API are documented here, including notab
 <!-- 1. TOC
 {:toc} -->
 
+## Version 1.13.2
+
+_Released 10/21/19_
+
+- **Bug fix.** Fixed a bug in list APIs that affected the ability to page through results when secondary indices of the storage were used to query data.
+
 ## Version 1.13.1
 
 _Released 10/21/19_

--- a/lib/data/account-data-aws/src/tables/AuditEntryTable.ts
+++ b/lib/data/account-data-aws/src/tables/AuditEntryTable.ts
@@ -198,6 +198,13 @@ export class AuditEntryTable extends AwsDynamoTable {
         expressionNames['#resource'] = 'resource';
         expressionValues[':resource'] = { S: options.resource };
       }
+
+      if (options.issuerId && identityFilter) {
+        const identity = { S: toIdentity({ issuerId: options.issuerId, subject: options.subject || '' }) };
+        filters.push('begins_with(#identity, :identity)');
+        expressionNames['#identity'] = 'identity';
+        expressionValues[':identity'] = identity;
+      }
     }
 
     const queryOptions = {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.13.1",
+  "version": "1.13.2",
   "private": true,
   "org": "5qtrs",
   "scripts": {


### PR DESCRIPTION
function-api, 1.13.2:

* Fix paging through data when selection criteria uses secondary indexes in Dynamo. 
* Small tweak to tests to allow them to run against locally hosted fusebit-api.