### PR TITLE
fusebit-cli: support for specifying subscription with fuse user acces…

### DIFF
--- a/cli/fusebit-cli/package.json
+++ b/cli/fusebit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/fusebit-cli",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "",
   "main": "libc/index.js",
   "bin": {

--- a/cli/fusebit-cli/src/commands/user/access/UserAccessAddCommand.ts
+++ b/cli/fusebit-cli/src/commands/user/access/UserAccessAddCommand.ts
@@ -23,6 +23,12 @@ const command = {
   ],
   options: [
     {
+      name: 'subscription',
+      aliases: ['s'],
+      description: 'The subscription to which access should be given to the user',
+      defaultText: 'profile value',
+    },
+    {
       name: 'boundary',
       aliases: ['b'],
       description: 'The boundary to which access should be given to the user',

--- a/docs/fusebit-cli.md
+++ b/docs/fusebit-cli.md
@@ -16,6 +16,12 @@ All public releases of the Fusebit CLI are documented here, including notable ch
 <!-- 1. TOC
 {:toc} -->
 
+## Version 1.3.0
+
+_Released 10/23/19_
+
+- **Permission command improvements.** The `fuse user access add` command now allows specification of the Fusebit subscription, making it useful for account-level administrative actions.
+
 ## Version 1.2.0
 
 _Released 10/21/19_


### PR DESCRIPTION
fusebit-cli 1.3.0:

* Add support for specifying subscription on `fuse user access add`. Useful for account-level admins. 