### PR TITLE
fusebit-ops-cli: support for credentials provider

### DIFF
--- a/cli/fusebit-ops-cli/package.json
+++ b/cli/fusebit-ops-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/fusebit-ops-cli",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "The Fusebit Platform Operations CLI",
   "main": "libc/index.js",
   "license": "UNLICENSED",

--- a/cli/fusebit-ops-cli/src/commands/InitCommand.ts
+++ b/cli/fusebit-ops-cli/src/commands/InitCommand.ts
@@ -36,6 +36,10 @@ const command = {
       description: 'The AWS user access key id',
     },
     {
+      name: 'credentialsProvider',
+      description: 'The AWS credentials provider command',
+    },
+    {
       name: 'profile',
       aliases: ['p'],
       description: 'The name of the profile to create with the initalization of the CLI',
@@ -66,6 +70,7 @@ export class InitCommand extends Command {
     const awsUserName = input.options.awsUserName as string;
     const awsSecretAccessKey = input.options.awsSecretAccessKey as string;
     const awsAccessKeyId = input.options.awsAccessKeyId as string;
+    const credentialsProvider = input.options.credentialsProvider as string;
 
     const profileService = await ProfileService.create(input);
 
@@ -89,6 +94,7 @@ export class InitCommand extends Command {
       awsUserName,
       awsSecretAccessKey,
       awsAccessKeyId,
+      credentialsProvider,
     };
 
     const settings = await profileService.promptForMissingSettings(initialSettings);

--- a/cli/fusebit-ops-cli/src/services/ProfileService.ts
+++ b/cli/fusebit-ops-cli/src/services/ProfileService.ts
@@ -21,15 +21,7 @@ const notSet = Text.dim(Text.italic('<not set>'));
 // ------------------
 
 function getDateString(date: Date) {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-
-  const dateOnly = new Date(date.valueOf());
-  dateOnly.setHours(0, 0, 0, 0);
-
-  const dateOnlyMs = dateOnly.valueOf();
-  const [dateString, timeString] = date.toLocaleString().split(',');
-  return dateOnlyMs === today.valueOf() ? timeString.trim() : dateString.trim();
+  return date.toLocaleString();
 }
 
 // ----------------
@@ -147,78 +139,95 @@ export class ProfileService {
 
   public async promptForMissingSettings(settings: any): Promise<IFusebitOpsProfileSettings> {
     const accountInfoNeeded = !settings.awsMainAccount;
-    const userInfoNeeded = !settings.awsUserName || !settings.awsAccessKeyId || !settings.awsSecretAccessKey;
+    const userInfoNeeded =
+      !settings.credentialsProvider &&
+      (!settings.awsUserName || !settings.awsAccessKeyId || !settings.awsSecretAccessKey);
+    let credentialsProviderInfoNeeded: boolean = false;
 
     const io = this.input.io;
     if (accountInfoNeeded || userInfoNeeded) {
       await io.writeLine(Text.bold("To initialize the Fusebit Ops CLI we'll need to collect some information."));
       await io.writeLine();
+      if (userInfoNeeded) {
+        const credentialsPrompt = await Confirm.create({
+          header: 'AWS Credentials',
+          message: 'Do you have a custom AWS credentials provider executable you want to use?',
+          details: [
+            {
+              name: 'Yes',
+              value:
+                'You will be asked for the full command line to the custom credentials provider executable, as documented at https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html',
+            },
+            {
+              name: 'No',
+              value:
+                'You will be asked to manually enter your IAM user name, access key ID, secret access key, and IAM role to assume',
+            },
+          ],
+        });
+        credentialsProviderInfoNeeded = await credentialsPrompt.prompt(this.input.io);
+      }
     }
 
     if (accountInfoNeeded) {
-      await io.writeLine(
-        [
-          'Please provide the following information about the AWS accounts on which you are hosting',
-          'your installation of the Fusebit platform. The main AWS account number',
-          'is required. If you use a different account for your AWS users, you can also',
-          'provide an optional AWS user account and the role in your AWS production',
-          'account to assume to gain access to your AWS production account.',
-        ].join(' ')
-      );
-      await io.writeLine();
       settings.awsMainAccount = await io.prompt({
         prompt: 'AWS Main Account Number:',
         placeholder: '(Required)',
         required: true,
       });
+    }
 
-      settings.awsUserAccount = await io.prompt({
-        prompt: 'AWS Users Account Number:',
-        placeholder: '(Optional)',
-      });
-
-      if (settings.awsUserAccount) {
+    if (userInfoNeeded) {
+      if (credentialsProviderInfoNeeded) {
+        settings.credentialsProvider = await io.prompt({
+          prompt: 'Custom AWS Credentials Provider Command:',
+          placeholder: '(Full command line)',
+          required: true,
+        });
+      } else {
+        settings.awsUserAccount = await io.prompt({
+          prompt: 'AWS Users Account Number:',
+          placeholder: '(Required)',
+          required: true,
+        });
         settings.awsMainRole = await io.prompt({
           prompt: 'AWS Role in the Main Account to Assume:',
           placeholder: '(Required)',
           required: true,
         });
+        const settingsPath = await this.profile.getSettingsPath();
+        await io.writeLine(
+          Text.create(
+            'Please provide information about the ',
+            Text.bold('individual'),
+            ' AWS user that you use to access the AWS account(s) on which you are ',
+            'hosting your installation of the Fusebit platform.',
+            Text.eol(),
+            Text.eol(),
+            Text.boldItalic(`Note: Your secret access key will be stored on disk at '${settingsPath}'`)
+          )
+        );
+        await io.writeLine();
+
+        settings.awsUserName = await io.prompt({
+          prompt: 'AWS User Name:',
+          placeholder: '(Required)',
+          required: true,
+        });
+
+        settings.awsAccessKeyId = await io.prompt({
+          prompt: 'AWS Access Key Id:',
+          placeholder: '(Required)',
+          required: true,
+        });
+
+        settings.awsSecretAccessKey = await io.prompt({
+          prompt: 'AWS Secret Access Key:',
+          placeholder: '(Required)',
+          required: true,
+          mask: true,
+        });
       }
-    }
-
-    if (userInfoNeeded) {
-      const settingsPath = await this.profile.getSettingsPath();
-      await io.writeLine(
-        Text.create(
-          'Please provide information about the ',
-          Text.bold('individual'),
-          ' AWS user that you use to access the AWS account(s) on which you are ',
-          'hosting your installation of the Fusebit platform.',
-          Text.eol(),
-          Text.eol(),
-          Text.boldItalic(`Note: Your secret access key will be stored on disk at '${settingsPath}'`)
-        )
-      );
-      await io.writeLine();
-
-      settings.awsUserName = await io.prompt({
-        prompt: 'AWS User Name:',
-        placeholder: '(Required)',
-        required: true,
-      });
-
-      settings.awsAccessKeyId = await io.prompt({
-        prompt: 'AWS Access Key Id:',
-        placeholder: '(Required)',
-        required: true,
-      });
-
-      settings.awsSecretAccessKey = await io.prompt({
-        prompt: 'AWS Secret Access Key:',
-        placeholder: '(Required)',
-        required: true,
-        mask: true,
-      });
     }
 
     return settings as IFusebitOpsProfileSettings;
@@ -344,9 +353,13 @@ export class ProfileService {
   private getProfileUpdateConfirmDetails(profile: IFusebitOpsProfile, settings: IFusebitOpsProfileSettings) {
     const awsAccessKeyId = profile.awsAccessKeyId || notSet;
     const awsSecretAccessKey = profile.awsSecretAccessKey || notSet;
+    const credentialsProvider = profile.credentialsProvider || notSet;
+    const awsUserName = profile.awsUserName || notSet;
 
     const newAccessKeyId = settings.awsAccessKeyId || notSet;
     const newSecretAccessKey = settings.awsSecretAccessKey || notSet;
+    const newCredentialsProvider = settings.credentialsProvider || notSet;
+    const newAwsUserName = settings.awsUserName || notSet;
 
     const accessKeyIdValue =
       awsAccessKeyId === newAccessKeyId
@@ -356,10 +369,19 @@ export class ProfileService {
       awsSecretAccessKey === newSecretAccessKey
         ? Text.create(secretKeyMasked, Text.dim(' (no change)'))
         : Text.create(secretKeyMasked, Text.dim(' → '), secretKeyMasked);
+    const credentialsProviderValue =
+      credentialsProvider === newCredentialsProvider
+        ? Text.create(credentialsProvider, Text.dim(' (no change)'))
+        : Text.create(credentialsProvider, Text.dim(' → '), newCredentialsProvider);
+    const awsUserNameValue =
+      awsUserName === newAwsUserName
+        ? Text.create(awsUserName, Text.dim(' (no change)'))
+        : Text.create(awsUserName, Text.dim(' → '), newAwsUserName);
 
     return [
       { name: 'Main Account', value: profile.awsMainAccount },
-      { name: 'User Name', value: profile.awsUserName },
+      { name: 'Credentials Provider', value: credentialsProviderValue },
+      { name: 'User Name', value: awsUserNameValue },
       { name: 'Access Key', value: accessKeyIdValue },
       { name: 'Secret Key', value: secretAccessKeyValue },
     ];
@@ -368,10 +390,11 @@ export class ProfileService {
   private getProfileConfirmDetails(profile: IFusebitOpsProfile) {
     return [
       { name: 'Main Account', value: profile.awsMainAccount },
+      { name: 'Credentials Provider', value: profile.credentialsProvider || notSet },
       { name: 'User Account', value: profile.awsUserAccount || notSet },
       { name: 'Main Role', value: profile.awsMainRole || notSet },
-      { name: 'User Name', value: profile.awsUserName },
-      { name: 'Access Key', value: profile.awsAccessKeyId },
+      { name: 'User Name', value: profile.awsUserName || notSet },
+      { name: 'Access Key', value: profile.awsAccessKeyId || notSet },
     ];
   }
 
@@ -418,44 +441,46 @@ export class ProfileService {
 
   private async writeProfile(profile: IFusebitOpsProfile, isDefault: boolean) {
     const details = [Text.dim('AWS Main Account: '), profile.awsMainAccount, Text.eol()];
-
-    if (profile.awsUserAccount) {
-      details.push(Text.dim('AWS User Account: '));
-      details.push(profile.awsUserAccount);
+    if (profile.credentialsProvider) {
+      details.push(Text.dim('Credentials provider: '));
+      details.push(profile.credentialsProvider);
       details.push(Text.eol());
-    }
-    if (profile.awsMainRole) {
-      details.push(Text.dim('AWS Main Role: '));
-      details.push(profile.awsMainRole);
-      details.push(Text.eol());
-    }
+    } else {
+      if (profile.awsUserAccount) {
+        details.push(Text.dim('AWS User Account: '));
+        details.push(profile.awsUserAccount);
+        details.push(Text.eol());
+      }
+      if (profile.awsMainRole) {
+        details.push(Text.dim('AWS Main Role: '));
+        details.push(profile.awsMainRole);
+        details.push(Text.eol());
+      }
 
-    if (profile.awsUserName) {
-      details.push(Text.dim('AWS User Name: '));
-      details.push(profile.awsUserName);
-      details.push(Text.eol());
-    }
+      if (profile.awsUserName) {
+        details.push(Text.dim('AWS User Name: '));
+        details.push(profile.awsUserName);
+        details.push(Text.eol());
+      }
 
-    if (profile.awsSecretAccessKey) {
-      details.push(Text.dim('AWS User Access Key Id: '));
-      details.push(profile.awsAccessKeyId);
-      details.push(Text.eol());
+      if (profile.awsSecretAccessKey) {
+        details.push(Text.dim('AWS User Access Key Id: '));
+        details.push(profile.awsAccessKeyId);
+        details.push(Text.eol());
+      }
     }
-
     details.push(
       ...[
         Text.dim('Created: '),
         getDateString(new Date(profile.created)),
-        Text.dim(' • '),
+        Text.eol(),
         Text.dim('Last Updated: '),
         getDateString(new Date(profile.updated)),
       ]
     );
-
     const name = isDefault
       ? Text.create(Text.bold(profile.name), Text.eol(), Text.dim(Text.italic('<default>')))
       : Text.bold(profile.name);
-
     await this.executeService.message(name, Text.create(details));
   }
 }

--- a/cli/fusebit-ops-cli/src/services/SetupService.ts
+++ b/cli/fusebit-ops-cli/src/services/SetupService.ts
@@ -81,13 +81,18 @@ export class SetupService {
     const profile = await this.profileService.getProfileOrDefaultOrThrow();
     const confirmPrompt = await Confirm.create({
       header: 'Setup the Fusebit platform?',
-      details: [
-        { name: 'Main Account', value: profile.awsMainAccount },
-        { name: 'User Account', value: profile.awsUserAccount || notSet },
-        { name: 'Main Role', value: profile.awsMainRole || notSet },
-        { name: 'User Name', value: profile.awsUserName },
-        { name: 'Access Key', value: profile.awsAccessKeyId },
-      ],
+      details: profile.credentialsProvider
+        ? [
+            { name: 'Main Account', value: profile.awsMainAccount },
+            { name: 'Credentials Provider', value: profile.credentialsProvider },
+          ]
+        : [
+            { name: 'Main Account', value: profile.awsMainAccount },
+            { name: 'User Account', value: profile.awsUserAccount || notSet },
+            { name: 'Main Role', value: profile.awsMainRole || notSet },
+            { name: 'User Name', value: profile.awsUserName || notSet },
+            { name: 'Access Key', value: profile.awsAccessKeyId || notSet },
+          ],
     });
     const confirmed = await confirmPrompt.prompt(this.input.io);
     if (!confirmed) {

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -15,7 +15,7 @@ This page contains download links for the components of the Fusebit platform. A 
 [Release notes]({{ site.baseurl }}{% link index.md %})
 
 - Fusebit CLI: `npm install -g @fusebit/cli`
-- Fusebit Operations CLI: <https://cdn.fusebit.io/fusebit/cli/fusebit-ops-cli-v1.17.tgz>
+- Fusebit Operations CLI: <https://cdn.fusebit.io/fusebit/cli/fusebit-ops-cli-v1.18.tgz>
 - Fusebit Operations Guide: <https://cdn.fusebit.io/fusebit/docs/fusebit-ops-guide-v1.pdf>
 - Fusebit Editor: <https://cdn.fusebit.io/fusebit/js/fusebit-editor/latest/fusebit-editor.min.js><br/>
   More information about the Fusebit CDN URL structure [here](https://fusebit.io/docs/integrator-guide/editor-integration/#including-the-fusebit-library)

--- a/docs/fusebit-ops-cli.md
+++ b/docs/fusebit-ops-cli.md
@@ -17,6 +17,12 @@ All public releases of the Fusebit Operations CLI are documented here, including
 {:toc}
 -->
 
+## Version 1.18.0
+
+_Released 11/12/19_
+
+- **Support for custom AWS credentials provider** Enable the specification of a custom AWS credentials provider in `fuse-ops init`.
+
 ## Version 1.17.0
 
 _Released 11/7/19_

--- a/lib/data/ops-data-aws/src/OpsDataAwsConfig.ts
+++ b/lib/data/ops-data-aws/src/OpsDataAwsConfig.ts
@@ -56,6 +56,10 @@ export class OpsDataAwsConfig implements IConfig {
     return value as string;
   }
 
+  public get credentialsProvider(): string {
+    return this.config.value('credentialsProvider') as string;
+  }
+
   public get mainAccountName(): string {
     return (this.config.value('mainAccountName') as string) || defaultMainAccountName;
   }

--- a/sdk/fusebit-ops-profile-sdk/src/FusebitOpsProfile.ts
+++ b/sdk/fusebit-ops-profile-sdk/src/FusebitOpsProfile.ts
@@ -13,11 +13,12 @@ const defaultDefaultProfileName = 'default';
 
 export interface IFusebitOpsProfileSettings {
   awsMainAccount: string;
-  awsUserName: string;
-  awsSecretAccessKey: string;
+  awsUserName?: string;
+  awsSecretAccessKey?: string;
   awsAccessKeyId: string;
   awsUserAccount?: string;
   awsMainRole?: string;
+  credentialsProvider?: string;
 }
 
 export interface IFusebitOpsProfile extends IFusebitOpsProfileSettings {
@@ -113,17 +114,27 @@ export class FusebitOpsProfile {
   }
 
   public async addProfile(name: string, settings: IFusebitOpsProfileSettings): Promise<IFusebitOpsProfile> {
+    if (
+      !settings.credentialsProvider &&
+      (!settings.awsUserName || !settings.awsAccessKeyId || !settings.awsSecretAccessKey)
+    ) {
+      throw new Error(
+        "A profile must sepecify either the 'credentialsProvider' or 'awsUserName', 'awsAccessKeyId', and 'awsSecretAccessKey'."
+      );
+    }
+
     const created = new Date().toLocaleString();
 
     const fullProfileToAdd = {
       created,
       updated: created,
       awsMainAccount: settings.awsMainAccount,
-      awsUserName: settings.awsUserName,
-      awsSecretAccessKey: settings.awsSecretAccessKey,
-      awsAccessKeyId: settings.awsAccessKeyId,
+      awsUserName: settings.awsUserName || undefined,
+      awsSecretAccessKey: settings.awsSecretAccessKey || undefined,
+      awsAccessKeyId: settings.awsAccessKeyId || undefined,
       awsUserAccount: settings.awsUserAccount || undefined,
       awsMainRole: settings.awsMainRole || undefined,
+      credentialsProvider: settings.credentialsProvider || undefined,
     };
 
     const profile = await this.dotConfig.setProfile(name, fullProfileToAdd);
@@ -145,6 +156,9 @@ export class FusebitOpsProfile {
     profile.awsSecretAccessKey = settings.awsSecretAccessKey;
     profile.awsAccessKeyId = settings.awsAccessKeyId;
 
+    if (settings.credentialsProvider !== undefined) {
+      profile.credentialsProvider = settings.credentialsProvider || undefined;
+    }
     if (settings.awsUserAccount !== undefined) {
       profile.awsUserAccount = settings.awsUserAccount || undefined;
     }


### PR DESCRIPTION
fusebit-ops-cli 1.18.0:

* Added support for a credentials_provider executable as a way to establish AWS credentials for performing OPS operations. When running `fuse-ops init`, users can now either specify a executable that returns a JSON structure as documented at https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html, or they can manually provide IAM user name, access key ID, secret access key, and IAM role as before. 