### PR TITLE
fusebit-cli: support for templates

### DIFF
--- a/cli/fusebit-cli/package.json
+++ b/cli/fusebit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/fusebit-cli",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "",
   "main": "libc/index.js",
   "bin": {

--- a/docs/fusebit-cli.md
+++ b/docs/fusebit-cli.md
@@ -16,6 +16,12 @@ All public releases of the Fusebit CLI are documented here, including notable ch
 <!-- 1. TOC
 {:toc} -->
 
+## Version 1.7.0
+
+_Released 11/15/19_
+
+- **Support for templates**. The `fuse function edit` command now allows creating or overriding functions from a template stored on Github, using `--template {org}/{repo}[/{directory}]` option. For sample templates, check [fusebit/samples](https://github.com/fusebit/samples) repository.
+
 ## Version 1.6.0
 
 _Released 11/13/19_

--- a/docs/fusebit-editor.md
+++ b/docs/fusebit-editor.md
@@ -16,6 +16,14 @@ All public releases of the Fusebit editor are documented here, including notable
 <!-- 1. TOC
 {:toc} -->
 
+## Version 1.3.0
+
+_Released 11/15/19_
+
+- **Support for specifying the file to select.** The file to be initially selected can now be configured through `INavigationPanelOptions.selectFile`.
+- **Runner improvement.** Improved error message when the runner is used before the function was saved.
+- **Bug fix.** The intially selected file is now highlighted in the navigation bar.
+
 ## Version 1.2.0
 
 _Released 10/17/19_

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,22 +20,22 @@ All public releases of the Fusebit platform components are documented here, incl
 <td>
 <ul>
 <li>
-Fusebit CLI <code>v1.4+</code> - <a href="{{ site.baseurl }}{% link fusebit-cli.md %}">release notes</a>
+Fusebit CLI <code>v1.7+</code> - <a href="{{ site.baseurl }}{% link fusebit-cli.md %}">release notes</a>
 </li>
 <li>
-Fusebit Editor <code>v1.2+</code> - <a href="{{ site.baseurl }}{% link fusebit-editor.md %}">release notes</a>
+Fusebit Editor <code>v1.3+</code> - <a href="{{ site.baseurl }}{% link fusebit-editor.md %}">release notes</a>
 </li>
 <li>
 Fusebit HTTP API <code>v1.13+</code> - <a href="{{ site.baseurl }}{% link fusebit-http-api.md %}">release notes</a>
 </li>
 <li>
-Fusebit Ops CLI <code>v1.14+</code> - <a href="{{ site.baseurl }}{% link fusebit-ops-cli.md %}">release notes</a></li>
+Fusebit Ops CLI <code>v1.18+</code> - <a href="{{ site.baseurl }}{% link fusebit-ops-cli.md %}">release notes</a></li>
 </ul>
 </td>
 <td style="width:30%">
 <dl>
   <dt>Last updated</dt>
-  <dd>11/4/19</dd>
+  <dd>11/15/19</dd>
   <dt>LTS release</dt>
   <dd>No</dd>
 </dl>

--- a/lib/client/fusebit-editor/package.json
+++ b/lib/client/fusebit-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/fusebit-editor",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "",
   "main": "libm/index.js",
   "browser": "libm/index.js",

--- a/lib/client/fusebit-editor/src/CreateEditor.ts
+++ b/lib/client/fusebit-editor/src/CreateEditor.ts
@@ -52,6 +52,11 @@ export function createEditor(
 
   return server.loadEditorContext(boundaryId, functionId, options).then(editorContext => {
     createEditorImpl(editorContext);
+    let selectedFile = editorContext.selectedFileName;
+    editorContext.selectedFileName = undefined;
+    if (selectedFile) {
+      editorContext.selectFile(selectedFile);
+    }
     return editorContext;
   });
 

--- a/lib/client/fusebit-editor/src/CreateLogsPanel.ts
+++ b/lib/client/fusebit-editor/src/CreateLogsPanel.ts
@@ -134,9 +134,13 @@ export function createLogsPanel(element: HTMLElement, editorContext: EditorConte
           lines.push(response.body.message);
         }
       } else if (responseSource === 'proxy' && response.body) {
-        lines.push(`RUN: infrastructure error HTTP ${response.statusCode}`);
-        if (response.body.message) {
-          lines.push(response.body.message);
+        if (response.statusCode === 404) {
+          lines.push('RUN: function not found. Did you save the function before running it?');
+        } else {
+          lines.push(`RUN: infrastructure error HTTP ${response.statusCode}`);
+          if (response.body.message) {
+            lines.push(response.body.message);
+          }
         }
       } else {
         lines.push(`RUN: function finished`, `HTTP ${response.statusCode}`);

--- a/lib/client/fusebit-editor/src/CreateNavigationPanel.ts
+++ b/lib/client/fusebit-editor/src/CreateNavigationPanel.ts
@@ -150,6 +150,13 @@ export function createNavigationPanel(
     }
   });
 
+  editorContext.on(Events.Events.FileSelected, (e: Events.FileSelectedEvent) => {
+    let element = findFileNameNavigationItemElement(e.fileName);
+    if (element) {
+      selectNavigationItem(element);
+    }
+  });
+
   let newFileElement = document.getElementById(newFileId) as HTMLElement;
   function addButtonClicked(e: Event) {
     e.preventDefault();

--- a/lib/client/fusebit-editor/src/EditorContext.ts
+++ b/lib/client/fusebit-editor/src/EditorContext.ts
@@ -144,14 +144,26 @@ export class EditorContext extends EventEmitter {
       this._ensureFusebitMetadata(true).runner = RunnerPlaceholder;
     }
     if (this.functionSpecification.nodejs.files) {
-      if (this.functionSpecification.nodejs.files['index.js']) {
-        this.selectFile('index.js');
+      const metadata = this._ensureFusebitMetadata();
+      let fileToSelect = 'index.js';
+      let hideFiles: any[] = [];
+      if (metadata.editor && typeof metadata.editor.navigationPanel === 'object') {
+        hideFiles = metadata.editor.navigationPanel.hideFiles || hideFiles;
+        fileToSelect = metadata.editor.navigationPanel.selectFile || fileToSelect;
+      }
+      if (this.functionSpecification.nodejs.files[fileToSelect] && hideFiles.indexOf(fileToSelect) < 0) {
+        this.selectFile(fileToSelect);
       } else {
-        const fileName = Object.keys(this.functionSpecification.nodejs.files)[0];
-        if (fileName) {
-          this.selectFile(fileName);
-        } else {
-          throw new Error('At least one file must be provided in functionSpecification.nodejs.files.');
+        let foundFileSelect = false;
+        for (var name in this.functionSpecification.nodejs.files) {
+          if (hideFiles.indexOf(name) < 0) {
+            this.selectFile(name);
+            foundFileSelect = true;
+            break;
+          }
+        }
+        if (!foundFileSelect) {
+          throw new Error('At least one non-hidden file must be provided in functionSpecification.nodejs.files.');
         }
       }
     } else {

--- a/lib/client/fusebit-editor/src/Options.ts
+++ b/lib/client/fusebit-editor/src/Options.ts
@@ -197,6 +197,10 @@ export interface INavigationPanelOptions {
    */
   hideFiles?: string[];
   /**
+   * A file name of the file to select when the editor starts.
+   */
+  selectFile?: string;
+  /**
    * Not in MVP
    * @ignore
    */


### PR DESCRIPTION
fusebit-cli 1.7.0: 

- **Support for templates**. The `fuse function edit` command now allows creating or overriding functions from a template stored on Github, using `--template {org}/{repo}[/{directory}]` option. For sample templates, check [fusebit/samples](https://github.com/fusebit/samples) repository.

fusebit-editor 1.3.0: 

- **Support for specifying the file to select.** The file to be initially selected can now be configured through `INavigationPanelOptions.selectFile`.
- **Runner improvement.** Improved error message when the runner is used before the function was saved.
- **Bug fix.** The intially selected file is now highlighted in the navigation bar.
