### PR TITLE
fusebit-ops-cli: support for existing VPC and subnets

### DIFF
--- a/cli/fusebit-ops-cli/package.json
+++ b/cli/fusebit-ops-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/fusebit-ops-cli",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "The Fusebit Platform Operations CLI",
   "main": "libc/index.js",
   "license": "UNLICENSED",

--- a/cli/fusebit-ops-cli/src/commands/network/AddNetworkCommand.ts
+++ b/cli/fusebit-ops-cli/src/commands/network/AddNetworkCommand.ts
@@ -26,6 +26,18 @@ const command = {
   ],
   options: [
     {
+      name: 'vpc',
+      description: 'ID of an existing VPC to use',
+    },
+    {
+      name: 'privateSubnets',
+      description: 'Comma-delimited list of existing private subnet IDs to use',
+    },
+    {
+      name: 'publicSubnets',
+      description: 'Comma-delimited list of existing public subnet IDs to use',
+    },
+    {
       name: 'confirm',
       aliases: ['c'],
       description: 'If set to true, prompts for confirmation before adding the network to the Fusebit platform',
@@ -53,10 +65,20 @@ export class AddNetworkCommand extends Command {
 
     const [networkName, accountName, region] = input.arguments as string[];
     const confirm = input.options.confirm as boolean;
+    const existingVpcId = (input.options.vpc as string) || undefined;
+    const existingPrivateSubnetIds = parseList((input.options.privateSubnets as string) || undefined);
+    const existingPublicSubnetIds = parseList((input.options.publicSubnets as string) || undefined);
 
     const networkService = await NetworkService.create(input);
 
-    const network = { networkName, accountName, region };
+    const network = {
+      networkName,
+      accountName,
+      region,
+      existingVpcId,
+      existingPrivateSubnetIds,
+      existingPublicSubnetIds,
+    };
     await networkService.checkNetworkExists(network);
 
     if (confirm) {
@@ -66,5 +88,13 @@ export class AddNetworkCommand extends Command {
     const addedNetwork = await networkService.addNetwork(network);
     await networkService.displayNetwork(addedNetwork);
     return 0;
+
+    function parseList(list?: string): string[] | undefined {
+      if (list) {
+        const result = list.split(',').map(l => l.trim());
+        return result.length > 0 ? result : undefined;
+      }
+      return undefined;
+    }
   }
 }

--- a/cli/fusebit-ops-cli/src/services/NetworkService.ts
+++ b/cli/fusebit-ops-cli/src/services/NetworkService.ts
@@ -3,7 +3,6 @@ import { Text } from '@5qtrs/text';
 import { IOpsNetwork, IOpsNewNetwork, IListOpsNetworkOptions, IListOpsNetworkResult } from '@5qtrs/ops-data';
 import { OpsService } from './OpsService';
 import { ExecuteService } from './ExecuteService';
-import { SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION } from 'constants';
 
 // ----------------
 // Exported Classes
@@ -117,6 +116,15 @@ export class NetworkService {
         { name: 'Network', value: network.networkName },
         { name: 'Account', value: network.accountName },
         { name: 'Region', value: network.region },
+        { name: 'VPC', value: network.existingVpcId || '<create new>' },
+        {
+          name: 'Private Subnets',
+          value: network.existingPrivateSubnetIds ? network.existingPrivateSubnetIds.join(', ') : '<create new>',
+        },
+        {
+          name: 'Public Subnets',
+          value: network.existingPublicSubnetIds ? network.existingPublicSubnetIds.join(', ') : '<create new>',
+        },
       ],
     });
     const confirmed = await confirmPrompt.prompt(this.input.io);

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -15,7 +15,7 @@ This page contains download links for the components of the Fusebit platform. A 
 [Release notes]({{ site.baseurl }}{% link index.md %})
 
 - Fusebit CLI: `npm install -g @fusebit/cli`
-- Fusebit Operations CLI: <https://cdn.fusebit.io/fusebit/cli/fusebit-ops-cli-v1.18.tgz>
+- Fusebit Operations CLI: <https://cdn.fusebit.io/fusebit/cli/fusebit-ops-cli-v1.20.tgz>
 - Fusebit Operations Guide: <https://cdn.fusebit.io/fusebit/docs/fusebit-ops-guide-v1.pdf>
 - Fusebit Editor: <https://cdn.fusebit.io/fusebit/js/fusebit-editor/latest/fusebit-editor.min.js><br/>
   More information about the Fusebit CDN URL structure [here](https://fusebit.io/docs/integrator-guide/editor-integration/#including-the-fusebit-library)

--- a/docs/fusebit-ops-cli.md
+++ b/docs/fusebit-ops-cli.md
@@ -17,6 +17,12 @@ All public releases of the Fusebit Operations CLI are documented here, including
 {:toc}
 -->
 
+## Version 1.20.0
+
+_Released 12/4/19_
+
+- **Support pre-existing VPC and subnets** Enable the specification of a pre-existing VPC and subnets in `fuse-ops network add`.
+
 ## Version 1.19.0
 
 _Released 11/19/19_

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,13 +29,13 @@ Fusebit Editor <code>v1.3+</code> - <a href="{{ site.baseurl }}{% link fusebit-e
 Fusebit HTTP API <code>v1.13+</code> - <a href="{{ site.baseurl }}{% link fusebit-http-api.md %}">release notes</a>
 </li>
 <li>
-Fusebit Ops CLI <code>v1.19+</code> - <a href="{{ site.baseurl }}{% link fusebit-ops-cli.md %}">release notes</a></li>
+Fusebit Ops CLI <code>v1.20+</code> - <a href="{{ site.baseurl }}{% link fusebit-ops-cli.md %}">release notes</a></li>
 </ul>
 </td>
 <td style="width:30%">
 <dl>
   <dt>Last updated</dt>
-  <dd>11/19/19</dd>
+  <dd>12/4/19</dd>
   <dt>LTS release</dt>
   <dd>No</dd>
 </dl>

--- a/lib/data/ops-data-aws/src/OpsNetworkData.ts
+++ b/lib/data/ops-data-aws/src/OpsNetworkData.ts
@@ -76,7 +76,12 @@ export class OpsNetworkData extends DataSource implements IOpsNetworkData {
 
   private async attachNetworkDetails(network: IOpsNewNetwork): Promise<IOpsNetwork> {
     const awsNetwork = await this.provider.getAwsNetworkFromAccount(network.accountName, network.region);
-    const networkDetails = await awsNetwork.ensureNetwork(network.networkName);
+    const networkDetails = await awsNetwork.ensureNetwork(
+      network.networkName,
+      network.existingVpcId,
+      network.existingPublicSubnetIds,
+      network.existingPrivateSubnetIds
+    );
     return {
       networkName: network.networkName,
       accountName: network.accountName,
@@ -84,11 +89,7 @@ export class OpsNetworkData extends DataSource implements IOpsNetworkData {
       vpcId: networkDetails.vpcId,
       securityGroupId: networkDetails.securityGroupId,
       lambdaSecurityGroupId: networkDetails.lambdaSecurityGroupId,
-      internetGatewayId: networkDetails.internetGatewayId,
-      natGatewayId: networkDetails.natGatewayId,
-      publicRouteTableId: networkDetails.publicRouteTableId,
       publicSubnets: networkDetails.publicSubnets,
-      privateRouteTableId: networkDetails.privateRouteTableId,
       privateSubnets: networkDetails.privateSubnets,
     };
   }

--- a/lib/data/ops-data/src/IOpsNetworkData.ts
+++ b/lib/data/ops-data/src/IOpsNetworkData.ts
@@ -8,17 +8,16 @@ export interface IOpsNewNetwork {
   networkName: string;
   accountName: string;
   region: string;
+  existingVpcId?: string;
+  existingPublicSubnetIds?: string[];
+  existingPrivateSubnetIds?: string[];
 }
 
 export interface IOpsNetwork extends IOpsNewNetwork {
   vpcId: string;
   securityGroupId: string;
   lambdaSecurityGroupId: string;
-  internetGatewayId: string;
-  natGatewayId: string;
-  publicRouteTableId: string;
   publicSubnets: IOpsSubnetDetail[];
-  privateRouteTableId: string;
   privateSubnets: IOpsSubnetDetail[];
 }
 


### PR DESCRIPTION
fusebit-ops-cli 1.20.0:

- **Support pre-existing VPC and subnets** Enable the specification of a pre-existing VPC and subnets in `fuse-ops network add`.