### PR TITLE
fusebit-ops-cli: fix 'fuse-ops network' commands in case pre-existing…

### DIFF
--- a/cli/fusebit-ops-cli/package.json
+++ b/cli/fusebit-ops-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/fusebit-ops-cli",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "The Fusebit Platform Operations CLI",
   "main": "libc/index.js",
   "license": "UNLICENSED",

--- a/docs/fusebit-ops-cli.md
+++ b/docs/fusebit-ops-cli.md
@@ -17,6 +17,12 @@ All public releases of the Fusebit Operations CLI are documented here, including
 {:toc}
 -->
 
+## Version 1.20.1
+
+_Released 12/11/19_
+
+- **Bug fix** Prevent attempted creation of a VPC and subnets on `fuse-ops network` commands that do not specify a pre-existing VPC and network.
+
 ## Version 1.20.0
 
 _Released 12/4/19_

--- a/lib/data/ops-data-aws/src/OpsNetworkData.ts
+++ b/lib/data/ops-data-aws/src/OpsNetworkData.ts
@@ -40,7 +40,7 @@ export class OpsNetworkData extends DataSource implements IOpsNetworkData {
       if (existing.region !== network.region) {
         throw OpsDataException.networkDifferentRegion(network.networkName, existing.region);
       }
-      await this.attachNetworkDetails(network);
+      await this.attachNetworkDetails(network, false);
       return true;
     } catch (error) {
       if (error.code === OpsDataExceptionCode.noNetwork) {
@@ -52,17 +52,17 @@ export class OpsNetworkData extends DataSource implements IOpsNetworkData {
 
   public async add(network: IOpsNewNetwork): Promise<IOpsNetwork> {
     await this.tables.networkTable.add(network);
-    return this.attachNetworkDetails(network);
+    return this.attachNetworkDetails(network, true);
   }
 
   public async get(networkName: string, region: string): Promise<IOpsNetwork> {
     const network = await this.tables.networkTable.get(networkName, region);
-    return this.attachNetworkDetails(network);
+    return this.attachNetworkDetails(network, false);
   }
 
   public async list(options?: IListOpsNetworkOptions): Promise<IListOpsNetworkResult> {
     const result = await this.tables.networkTable.list(options);
-    const items = await Promise.all(result.items.map(network => this.attachNetworkDetails(network)));
+    const items = await Promise.all(result.items.map(network => this.attachNetworkDetails(network, false)));
     return {
       next: result.next,
       items,
@@ -71,13 +71,14 @@ export class OpsNetworkData extends DataSource implements IOpsNetworkData {
 
   public async listAll(networkName?: string): Promise<IOpsNetwork[]> {
     const networks = await this.tables.networkTable.listAll(networkName);
-    return Promise.all(networks.map(network => this.attachNetworkDetails(network)));
+    return Promise.all(networks.map(network => this.attachNetworkDetails(network, false)));
   }
 
-  private async attachNetworkDetails(network: IOpsNewNetwork): Promise<IOpsNetwork> {
+  private async attachNetworkDetails(network: IOpsNewNetwork, createIfNotExists: boolean): Promise<IOpsNetwork> {
     const awsNetwork = await this.provider.getAwsNetworkFromAccount(network.accountName, network.region);
     const networkDetails = await awsNetwork.ensureNetwork(
       network.networkName,
+      createIfNotExists,
       network.existingVpcId,
       network.existingPublicSubnetIds,
       network.existingPrivateSubnetIds


### PR DESCRIPTION
… networking is used

fuse-ops-cli: 

- **Bug fix** Prevent attempted creation of a VPC and subnets on `fuse-ops network` commands that do not specify a pre-existing VPC and network.