### PR TITLE
Fix HTTP 502s from AWS ALB

### DIFF
--- a/docs/fusebit-http-api.md
+++ b/docs/fusebit-http-api.md
@@ -16,6 +16,12 @@ All public releases of the Fusebit HTTP API are documented here, including notab
 <!-- 1. TOC
 {:toc} -->
 
+## Version 1.14.2
+
+_Released 1/22/20_
+
+- **Bug fix** Mitigation for a race condition in keep-alive timing between AWS ALB and Fusebit server that resulted in sporadic HTTP 502 responses.
+
 ## Version 1.14.1
 
 _Released 1/13/20_

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.14.1",
+  "version": "1.14.2",
   "private": true,
   "org": "5qtrs",
   "scripts": {


### PR DESCRIPTION
functions-api 1.14.2:

- **Bug fix** Mitigation for a race condition in keep-alive timing between AWS ALB and Fusebit server that resulted in sporadic HTTP 502 responses.

Background info: https://github.com/nodejs/node/issues/27363

This was reported by FF.