### PR TITLE
Increase execution request body size limit from 100kb to 500kb

### DIFF
--- a/api/function-api/src/routes/middleware/parse_body_conditional.js
+++ b/api/function-api/src/routes/middleware/parse_body_conditional.js
@@ -1,14 +1,12 @@
-const parse_json = require('express').json();
+const parse_json = require('express').json({ limit: 500 * 1024 });
 const Assert = require('assert');
 
 module.exports = function parse_body_conditional_factory(options) {
-    Assert.ok(options);
-    Assert.equal(typeof options.condition, 'function');
-    Assert.equal(options.condition.length, 1); // req => boolean
+  Assert.ok(options);
+  Assert.equal(typeof options.condition, 'function');
+  Assert.equal(options.condition.length, 1); // req => boolean
 
-    return function parse_body_conditional(req, res, next) {
-        return options.condition(req)
-            ? parse_json(req, res, next)
-            : next();
-    };
+  return function parse_body_conditional(req, res, next) {
+    return options.condition(req) ? parse_json(req, res, next) : next();
+  };
 };

--- a/api/function-api/test/function.test.ts
+++ b/api/function-api/test/function.test.ts
@@ -558,14 +558,20 @@ describe('function', () => {
     expect(response.data).toEqual({ items: expect.any(Array), next: expect.any(String) });
     expect(response.data.items).toHaveLength(2);
     expect(response.data.items).toEqual(
-      expect.arrayContaining([{ boundaryId, functionId: function1Id }, { boundaryId, functionId: function2Id }])
+      expect.arrayContaining([
+        { boundaryId, functionId: function1Id },
+        { boundaryId, functionId: function2Id },
+      ])
     );
     response = await listFunctions(account, boundaryId, undefined, 2, response.data.next);
     expect(response.status).toEqual(200);
     expect(response.data).toEqual({ items: expect.any(Array), next: expect.any(String) });
     expect(response.data.items).toHaveLength(2);
     expect(response.data.items).toEqual(
-      expect.arrayContaining([{ boundaryId, functionId: function3Id }, { boundaryId, functionId: function4Id }])
+      expect.arrayContaining([
+        { boundaryId, functionId: function3Id },
+        { boundaryId, functionId: function4Id },
+      ])
     );
     response = await listFunctions(account, boundaryId, undefined, 2, response.data.next);
     expect(response.status).toEqual(200);
@@ -823,7 +829,7 @@ describe('function', () => {
       status: 400,
       statusCode: 400,
       message: [
-        "The value of 'schedule.cron' body parameter must be a valid CRON expression.",
+        "The value of 'cron' parameter must be a valid CRON expression.",
         'Check https://crontab.guru/ for reference',
       ].join(' '),
     });
@@ -846,7 +852,7 @@ describe('function', () => {
       status: 400,
       statusCode: 400,
       message: [
-        "The value of 'schedule.timezone' body parameter must be a valid timezone identifier.",
+        "The value of 'timezone' parameter must be a valid timezone identifier.",
         'Check https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for reference',
       ].join(' '),
     });

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -6,7 +6,7 @@ nav_exclude: true
 
 # Downloads
 
-_Last updated January 29, 2029_
+_Last updated February 28, 2029_
 
 This page contains download links for the components of the Fusebit platform. A description of our versioning and support policy is available [here](https://fusebit.io/docs/integrator-guide/versioning/).
 
@@ -21,4 +21,4 @@ This page contains download links for the components of the Fusebit platform. A 
   More information about the Fusebit CDN URL structure [here](https://fusebit.io/docs/integrator-guide/editor-integration/#including-the-fusebit-library)
 - Fusebit HTTP API
   - Cloud deployment - `https://api.{region}.fusebit.io/v1`
-  - Private deployment image - `fuse-ops image pull 1.14.2`
+  - Private deployment image - `fuse-ops image pull 1.14.3`

--- a/docs/fusebit-http-api.md
+++ b/docs/fusebit-http-api.md
@@ -16,6 +16,12 @@ All public releases of the Fusebit HTTP API are documented here, including notab
 <!-- 1. TOC
 {:toc} -->
 
+## Version 1.14.3
+
+_Released 2/28/20_
+
+- **Limit increase** Increase default limit for the size of the body of the function execution request from 100KB to 500KB.
+
 ## Version 1.14.2
 
 _Released 1/22/20_

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ Fusebit Ops CLI <code>v1.21+</code> - <a href="{{ site.baseurl }}{% link fusebit
 <td style="width:30%">
 <dl>
   <dt>Last updated</dt>
-  <dd>1/29/20</dd>
+  <dd>2/28/20</dd>
   <dt>LTS release</dt>
   <dd>No</dd>
 </dl>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.14.2",
+  "version": "1.14.3",
   "private": true,
   "org": "5qtrs",
   "scripts": {


### PR DESCRIPTION
fusebit-api, 1.14.3:

- **Limit increase** Increase default limit for the size of the body of the function execution request from 100KB to 500KB.