### PR TITLE
Fix #569. Modify the blank return test to actually return nothing.

### DIFF
--- a/api/function-api/test/execution.async.test.ts
+++ b/api/function-api/test/execution.async.test.ts
@@ -144,7 +144,7 @@ describe('execution', () => {
     let response = await putFunction(account, boundaryId, function1Id, {
       nodejs: {
         files: {
-          'index.js': `module.exports = async (ctx) => { return {}; };`,
+          'index.js': `module.exports = async (ctx) => { };`,
         },
       },
     });


### PR DESCRIPTION
fixes #569 