### PR TITLE
Fix #530. Add unhandled exceptions to real-time logs

### DIFF
--- a/cli/fusebit-cli/package.json
+++ b/cli/fusebit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/fusebit-cli",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "",
   "main": "libc/index.js",
   "bin": {

--- a/cli/fusebit-cli/src/services/FunctionService.ts
+++ b/cli/fusebit-cli/src/services/FunctionService.ts
@@ -549,6 +549,14 @@ export class FunctionService {
                   }
                   this.input.io.write(Text.dim(`[${new Date(parsed.time).toLocaleTimeString()}] `));
                   this.input.io.writeLineRaw(parsed.level > 30 ? Text.red(parsed.msg).toString() : parsed.msg);
+                  if (parsed.properties) {
+                    let trace = parsed.properties.trace || parsed.properties.stackTrace;
+                    if (trace && Array.isArray(trace)) {
+                      trace.forEach(line => {
+                        this.input.io.writeLineRaw(parsed.level > 30 ? Text.red(line).toString() : line);
+                      });
+                    }
+                  }
                 }
               }
             },
@@ -617,9 +625,7 @@ export class FunctionService {
       },
       {
         method: 'GET',
-        url: `${profile.baseUrl}/v1/account/${profile.account}/subscription/${
-          profile.subscription
-        }${boundaryUrl}${queryString}`,
+        url: `${profile.baseUrl}/v1/account/${profile.account}/subscription/${profile.subscription}${boundaryUrl}${queryString}`,
         headers: { Authorization: `bearer ${profile.accessToken}` },
       }
     );
@@ -764,9 +770,7 @@ export class FunctionService {
       },
       {
         method: 'PUT',
-        url: `${profile.baseUrl}/v1/account/${profile.account}/subscription/${profile.subscription}/boundary/${
-          profile.boundary
-        }/function/${profile.function}`,
+        url: `${profile.baseUrl}/v1/account/${profile.account}/subscription/${profile.subscription}/boundary/${profile.boundary}/function/${profile.function}`,
         headers: {
           Authorization: `Bearer ${profile.accessToken}`,
         },

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -6,7 +6,7 @@ nav_exclude: true
 
 # Downloads
 
-_Last updated March 20, 2020_
+_Last updated March 26, 2020_
 
 This page contains download links for the components of the Fusebit platform. A description of our versioning and support policy is available [here](https://fusebit.io/docs/integrator-guide/versioning/).
 
@@ -21,4 +21,4 @@ This page contains download links for the components of the Fusebit platform. A 
   More information about the Fusebit CDN URL structure [here](https://fusebit.io/docs/integrator-guide/editor-integration/#including-the-fusebit-library)
 - Fusebit HTTP API
   - Cloud deployment - `https://api.{region}.fusebit.io/v1`
-  - Private deployment image - `fuse-ops image pull 1.15.0`
+  - Private deployment image - `fuse-ops image pull 1.15.1`

--- a/docs/fusebit-cli.md
+++ b/docs/fusebit-cli.md
@@ -16,6 +16,12 @@ All public releases of the Fusebit CLI are documented here, including notable ch
 <!-- 1. TOC
 {:toc} -->
 
+## Version 1.8.1
+
+_Released 3/26/20_
+
+- **Support exceptions in real-time logs**. The `fuse function log` command now displays information about errors returned from Fusebit functions as well as unhanded exceptions thrown by Fusebit function code.
+
 ## Version 1.8.0
 
 _Released 1/7/20_

--- a/docs/fusebit-http-api.md
+++ b/docs/fusebit-http-api.md
@@ -16,6 +16,12 @@ All public releases of the Fusebit HTTP API are documented here, including notab
 <!-- 1. TOC
 {:toc} -->
 
+## Version 1.15.1
+
+_Released 3/26/20_
+
+- **Real-time logging improvements** The real-time logging endpoint now returns information about errors returned from Fusebit functions as well as unhanded exceptions thrown by Fusebit function code.
+
 ## Version 1.15.0
 
 _Released 3/20/20_

--- a/lib/server/function-lambda/lambda/executor/executor.js
+++ b/lib/server/function-lambda/lambda/executor/executor.js
@@ -9,6 +9,19 @@ var bunyanLevels = { log: 30, error: 50 };
 
 var logs;
 
+// Wrap Lambda's uncaughtException handler to ensure logs are flushed before terminating the process
+var originalUncaughtException = (process.listeners('uncaughtException') || [])[0];
+process.removeAllListeners('uncaughtException');
+process.on('uncaughtException', (e, a) => {
+  sendLogsNow(() => {
+    if (originalUncaughtException) {
+      originalUncaughtException(e, a);
+    } else {
+      throw e;
+    }
+  });
+});
+
 exports.execute = function execute(event, context, cb) {
   Assert.equal(typeof handler, 'function', 'The module export must be a function.');
 
@@ -18,7 +31,7 @@ exports.execute = function execute(event, context, cb) {
   cb = updateLogs(event, cb);
 
   // Handle the asynchronous case
-  if (handler.constructor.name === "AsyncFunction") {
+  if (handler.constructor.name === 'AsyncFunction') {
     Assert.equal(handler.length, 1, 'The function must take one parameter: async (ctx).');
 
     // Guarantee the logs are sent after the Promise completes.
@@ -33,7 +46,6 @@ exports.execute = function execute(event, context, cb) {
   try {
     handler(event, cb);
   } catch (e) {
-    console.error('EXECUTION ERROR', e);
     return cb(e);
   }
 };

--- a/lib/server/function-lambda/src/execute_function.js
+++ b/lib/server/function-lambda/src/execute_function.js
@@ -4,6 +4,7 @@ const create_error = require('http-errors');
 const Jwt = require('jsonwebtoken');
 const BqMetering = require('@5qtrs/bq-metering');
 const ConnectionCache = require('./log_connection_cache');
+const write_logs = require('./write_logs');
 
 const realTimeLogsEnabled = !process.env.LOGS_DISABLE;
 
@@ -26,16 +27,12 @@ module.exports = function lambda_execute_function(req, res, next) {
           return next(create_error(404));
         } else if (e.code === 'TooManyRequestsException') {
           console.log(
-            `ERROR: Lambda concurrency limit exceeded when running function ${req.params.subscriptionId}/${
-              req.params.boundaryId
-            }/${req.params.functionId}`
+            `ERROR: Lambda concurrency limit exceeded when running function ${req.params.subscriptionId}/${req.params.boundaryId}/${req.params.functionId}`
           );
           return next(create_error(503));
         } else {
           console.log(
-            `ERROR: error executing Lambda function ${req.params.subscriptionId}/${req.params.boundaryId}/${
-              req.params.functionId
-            }: ${e.code} ${e.message}`
+            `ERROR: error executing Lambda function ${req.params.subscriptionId}/${req.params.boundaryId}/${req.params.functionId}: ${e.code} ${e.message}`
           );
           return next(
             create_error(
@@ -84,14 +81,21 @@ module.exports = function lambda_execute_function(req, res, next) {
         }
 
         if (r.FunctionError) {
-          res.set('x-fx-response-source', 'provider');
-          res.status(500);
-          return res.json({
-            status: 500,
-            statusCode: 500,
-            message: r.Payload.errorMessage || r.Payload.message,
-            properties: r.Payload,
-          });
+          const msg = r.Payload.errorMessage || r.Payload.message;
+          return write_logs(
+            req.params, // .subscriptionId, .boundaryId, .functionId
+            [{ level: 50, msg, time: new Date().toISOString(), properties: r.Payload }],
+            e => {
+              res.set('x-fx-response-source', 'provider');
+              res.status(500);
+              return res.json({
+                status: 500,
+                statusCode: 500,
+                message: msg,
+                properties: r.Payload,
+              });
+            }
+          );
         }
         res.set('x-fx-response-source', 'function');
         if (r.Payload) {
@@ -116,16 +120,12 @@ module.exports = function lambda_execute_function(req, res, next) {
         }
       } catch (e) {
         console.log(
-          `ERROR: error processing response from Lambda function ${req.params.subscriptionId}/${
-            req.params.boundaryId
-          }/${req.params.functionId}: ${e.code} ${e.message}`
+          `ERROR: error processing response from Lambda function ${req.params.subscriptionId}/${req.params.boundaryId}/${req.params.functionId}: ${e.code} ${e.message}`
         );
         return next(
           create_error(
             500,
-            `Error processing response from function ${req.params.subscriptionId}/${req.params.boundaryId}/${
-              req.params.functionId
-            }: ${e.message}`
+            `Error processing response from function ${req.params.subscriptionId}/${req.params.boundaryId}/${req.params.functionId}: ${e.message}`
           )
         );
       }

--- a/lib/server/function-lambda/src/post_logs.js
+++ b/lib/server/function-lambda/src/post_logs.js
@@ -1,55 +1,7 @@
-const { DynamoDB } = require('aws-sdk');
+const write_logs = require('./write_logs');
 
-const dynamo = new DynamoDB({ apiVersion: '2012-08-10' });
-const logTableName = `${process.env.DEPLOYMENT_KEY}.log`;
-
-module.exports = function lambda_post_logs(req, res, next) {
-  const logDetails = req.logs;
-  const logEntries = req.body;
-  // console.log('LOGS', logDetails, logEntries);
-  const subscriptionBoundary = { S: `${logDetails.subscriptionId}/${logDetails.boundaryId}` };
-  const functionId = { S: logDetails.functionId };
-
-  let i = 0;
-  const writeBatchToDynamo = () => {
-    const params = { RequestItems: {} };
-    const items = (params.RequestItems[logTableName] = []);
-
-    const batch = logEntries.splice(0, 25);
-    const now = Date.now();
-    const name = `application:${logDetails.subscriptionId}:${logDetails.boundaryId}:${logDetails.functionId}`;
-
-    for (const entry of batch) {
-      const time = Date.now() * 10000;
-      const count = (i++ % 100) * 100;
-      const random = Math.floor(Math.random() * 99);
-      items.push({
-        PutRequest: {
-          Item: {
-            subscriptionBoundary,
-            functionId,
-            timestamp: { N: (time + count + random).toString() },
-            ttl: { N: (Math.floor(now / 1000) + 60).toString() },
-            entry: { S: JSON.stringify({ name, level: entry.level, msg: entry.msg, time: entry.time }) },
-          },
-        },
-      });
-    }
-
-    dynamo.batchWriteItem(params, error => {
-      if (error) {
-        console.log(error);
-        res.send(500);
-        return;
-      }
-
-      if (logEntries.length) {
-        return writeBatchToDynamo();
-      }
-
-      res.send(200);
-    });
-  };
-
-  writeBatchToDynamo();
+module.exports = function lambda_post_logs(req, res) {
+  return write_logs(req.logs, req.body, e => {
+    res.send(e ? 500 : 200);
+  });
 };

--- a/lib/server/function-lambda/src/write_logs.js
+++ b/lib/server/function-lambda/src/write_logs.js
@@ -1,0 +1,56 @@
+const { DynamoDB } = require('aws-sdk');
+
+const dynamo = new DynamoDB({ apiVersion: '2012-08-10' });
+const logTableName = `${process.env.DEPLOYMENT_KEY}.log`;
+
+module.exports = function dynamodb_write_logs(logDetails, logEntries, cb) {
+  // console.log('WRITING LOGS', logDetails, logEntries);
+  const subscriptionBoundary = { S: `${logDetails.subscriptionId}/${logDetails.boundaryId}` };
+  const functionId = { S: logDetails.functionId };
+
+  let i = 0;
+  const writeBatchToDynamo = () => {
+    const params = { RequestItems: {} };
+    const items = (params.RequestItems[logTableName] = []);
+
+    const batch = logEntries.splice(0, 25);
+    const now = Date.now();
+    const name = `application:${logDetails.subscriptionId}:${logDetails.boundaryId}:${logDetails.functionId}`;
+
+    for (const entry of batch) {
+      const newEntry = { name, level: entry.level, msg: entry.msg, time: entry.time };
+      if (entry.properties) {
+        newEntry.properties = entry.properties;
+      }
+      const time = Date.now() * 10000;
+      const count = (i++ % 100) * 100;
+      const random = Math.floor(Math.random() * 99);
+      items.push({
+        PutRequest: {
+          Item: {
+            subscriptionBoundary,
+            functionId,
+            timestamp: { N: (time + count + random).toString() },
+            ttl: { N: (Math.floor(now / 1000) + 60).toString() },
+            entry: { S: JSON.stringify(newEntry) },
+          },
+        },
+      });
+    }
+
+    dynamo.batchWriteItem(params, error => {
+      if (error) {
+        console.log(error);
+        return cb(error);
+      }
+
+      if (logEntries.length) {
+        return writeBatchToDynamo();
+      }
+
+      return cb();
+    });
+  };
+
+  writeBatchToDynamo();
+};

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.15.0",
+  "version": "1.15.1",
   "private": true,
   "org": "5qtrs",
   "scripts": {


### PR DESCRIPTION
function-api 1.15.1:

- **Real-time logging improvements** The real-time logging endpoint now returns information about errors returned from Fusebit functions as well as unhanded exceptions thrown by Fusebit function code.

fusebit-cli 1.8.1:

- **Support exceptions in real-time logs**. The `fuse function log` command now displays information about errors returned from Fusebit functions as well as unhanded exceptions thrown by Fusebit function code.