### PR TITLE
Fix #598. Update compute settings of a function when the HTTP PUT onl…

### DIFF
--- a/api/function-api/test/function.legacy.test.ts
+++ b/api/function-api/test/function.legacy.test.ts
@@ -337,15 +337,15 @@ describe('function', () => {
   }, 20000);
 
   test('PUT with empty compute resets compute', async () => {
-    let response = await putFunction(account, boundaryId, function1Id, helloWorldWithStaticIp);
+    let response = await putFunction(account, boundaryId, function1Id, helloWorldWithComputeSettings);
     expect(response.status).toEqual(200);
     expect(response.data.status).toEqual('success');
 
     response = await getFunction(account, boundaryId, function1Id);
 
     expect(response.status).toEqual(200);
-    expect(response.data.compute).toEqual({ timeout: 30, memorySize: 128, staticIp: true });
-    expect(response.data.metadata.fusebit.computeSettings).toEqual('staticIp=true\nmemorySize=128\ntimeout=30');
+    expect(response.data.compute).toEqual({ timeout: 120, memorySize: 128, staticIp: false });
+    expect(response.data.metadata.fusebit.computeSettings).toEqual('timeout= 120\nmemorySize=128\nstaticIp=false');
 
     response.data.compute = {};
     response = await putFunction(account, boundaryId, function1Id, response.data);
@@ -467,15 +467,15 @@ describe('function', () => {
   }, 20000);
 
   test('PUT with undefined compute and undefined computeSettings resets compute', async () => {
-    let response = await putFunction(account, boundaryId, function1Id, helloWorldWithStaticIp);
+    let response = await putFunction(account, boundaryId, function1Id, helloWorldWithComputeSettings);
     expect(response.status).toEqual(200);
     expect(response.data.status).toEqual('success');
 
     response = await getFunction(account, boundaryId, function1Id);
 
     expect(response.status).toEqual(200);
-    expect(response.data.metadata.fusebit.computeSettings).toEqual('staticIp=true\nmemorySize=128\ntimeout=30');
-    expect(response.data.compute).toEqual({ timeout: 30, memorySize: 128, staticIp: true });
+    expect(response.data.metadata.fusebit.computeSettings).toEqual('timeout= 120\nmemorySize=128\nstaticIp=false');
+    expect(response.data.compute).toEqual({ timeout: 120, memorySize: 128, staticIp: false });
 
     response.data.metadata.fusebit.computeSettings = undefined;
     response.data.compute = undefined;

--- a/api/function-api/test/function.serialized.test.ts
+++ b/api/function-api/test/function.serialized.test.ts
@@ -253,15 +253,15 @@ describe('function', () => {
   }, 20000);
 
   test('PUT with empty compute resets compute', async () => {
-    let response = await putFunction(account, boundaryId, function1Id, helloWorldWithStaticIp);
+    let response = await putFunction(account, boundaryId, function1Id, helloWorldWithComputeSerialized);
     expect(response.status).toBe(200);
     expect(response.data.status).toBe('success');
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
     expect(response.status).toBe(200);
-    expect(response.data.compute).toEqual({ timeout: 30, memorySize: 128, staticIp: true });
-    expect(response.data.computeSerialized).toBe('staticIp=true\nmemorySize=128\ntimeout=30');
+    expect(response.data.compute).toEqual({ timeout: 120, memorySize: 128, staticIp: false });
+    expect(response.data.computeSerialized).toBe('timeout= 120\nmemorySize=128\nstaticIp=false');
 
     response.data.compute = {};
     response = await putFunction(account, boundaryId, function1Id, response.data);
@@ -367,15 +367,15 @@ describe('function', () => {
   }, 20000);
 
   test('PUT with undefined compute and undefined computeSerialized resets compute', async () => {
-    let response = await putFunction(account, boundaryId, function1Id, helloWorldWithStaticIp);
+    let response = await putFunction(account, boundaryId, function1Id, helloWorldWithComputeSerialized);
     expect(response.status).toBe(200);
     expect(response.data.status).toBe('success');
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
     expect(response.status).toBe(200);
-    expect(response.data.compute).toEqual({ timeout: 30, memorySize: 128, staticIp: true });
-    expect(response.data.computeSerialized).toBe('staticIp=true\nmemorySize=128\ntimeout=30');
+    expect(response.data.compute).toEqual({ timeout: 120, memorySize: 128, staticIp: false });
+    expect(response.data.computeSerialized).toBe('timeout= 120\nmemorySize=128\nstaticIp=false');
 
     response.data.computeSerialized = undefined;
     response.data.compute = undefined;

--- a/api/function-api/test/function.test.ts
+++ b/api/function-api/test/function.test.ts
@@ -94,7 +94,7 @@ const helloWorldWithComputeSettings = {
   },
   metadata: {
     fusebit: {
-      computeSettings: 'timeout=120',
+      computeSettings: 'timeout= 120',
     },
   },
 };
@@ -190,14 +190,14 @@ describe('function', () => {
   }, 20000);
 
   test('PUT with empty compute resets compute', async () => {
-    let response = await putFunction(account, boundaryId, function1Id, helloWorldWithStaticIp);
+    let response = await putFunction(account, boundaryId, function1Id, helloWorldWithComputeSettings);
     expect(response.status).toEqual(200);
     expect(response.data.status).toEqual('success');
 
     response = await getFunction(account, boundaryId, function1Id);
 
     expect(response.status).toEqual(200);
-    expect(response.data.compute).toEqual({ timeout: 30, memorySize: 128, staticIp: true });
+    expect(response.data.compute).toEqual({ timeout: 120, memorySize: 128, staticIp: false });
     expect(response.data.metadata).toBeUndefined();
 
     response.data.compute = {};
@@ -257,14 +257,14 @@ describe('function', () => {
   }, 20000);
 
   test('PUT with undefined compute resets compute', async () => {
-    let response = await putFunction(account, boundaryId, function1Id, helloWorldWithStaticIp);
+    let response = await putFunction(account, boundaryId, function1Id, helloWorldWithComputeSettings);
     expect(response.status).toEqual(200);
     expect(response.data.status).toEqual('success');
 
     response = await getFunction(account, boundaryId, function1Id);
 
     expect(response.status).toEqual(200);
-    expect(response.data.compute).toEqual({ timeout: 30, memorySize: 128, staticIp: true });
+    expect(response.data.compute).toEqual({ timeout: 120, memorySize: 128, staticIp: false });
     expect(response.data.metadata).toBeUndefined();
 
     response.data.compute = undefined;

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -6,7 +6,7 @@ nav_exclude: true
 
 # Downloads
 
-_Last updated April 14, 2020_
+_Last updated May 2, 2020_
 
 This page contains download links for the components of the Fusebit platform. A description of our versioning and support policy is available [here](https://fusebit.io/docs/integrator-guide/versioning/).
 
@@ -21,4 +21,4 @@ This page contains download links for the components of the Fusebit platform. A 
   More information about the Fusebit CDN URL structure [here](https://fusebit.io/docs/integrator-guide/editor-integration/#including-the-fusebit-library)
 - Fusebit HTTP API
   - Cloud deployment - `https://api.{region}.fusebit.io/v1`
-  - Private deployment image - `fuse-ops image pull 1.15.2`
+  - Private deployment image - `fuse-ops image pull 1.15.3`

--- a/docs/release-notes/fusebit-http-api.md
+++ b/docs/release-notes/fusebit-http-api.md
@@ -17,6 +17,12 @@ All public releases of the Fusebit HTTP API are documented here, including notab
 <!-- 1. TOC
 {:toc} -->
 
+## Version 1.15.3
+
+_Released 5/2/20_
+
+- **Bug fix** Fix a bug in HTTP PUT function API which prevented the effective compute settings of an existing function to be updated if the only change in the function specification was the compute settings.
+
 ## Version 1.15.2
 
 _Released 4/14/20_

--- a/lib/server/function-lambda/src/put_function.js
+++ b/lib/server/function-lambda/src/put_function.js
@@ -155,7 +155,10 @@ module.exports.core = function lambda_put_function_core(options, cb) {
       cb => resolve_settings(ctx, cb),
       cb => resolve_package_json(ctx, cb),
       cb => compute_build_plan(ctx, cb),
-      // (cb) => { console.log('BUILD PLAN', ctx.options.internal); cb(); },
+      // cb => {
+      //   console.log('BUILD PLAN', ctx.options.internal);
+      //   cb();
+      // },
       cb => save_function_build_status(ctx, cb),
       cb => save_function_build_request(ctx, cb),
       cb =>
@@ -403,6 +406,11 @@ function compute_build_plan_core(ctx, cb) {
     return set_build('configuration_update');
   }
 
+  if (hashes.serialized !== existingHashes.serialized) {
+    // Configuration has changed, code/dependencies/runtime has not
+    return set_build('configuration_update');
+  }
+
   if (ctx.options.internal.cron_plan !== 'none') {
     // CRON schedule has changed
     return set_build('configuration_update');
@@ -411,11 +419,6 @@ function compute_build_plan_core(ctx, cb) {
   if (hashes.metadata !== existingHashes.metadata) {
     // Only metadata has changed, no need to touch the function.
     return set_build('metadata_update');
-  }
-
-  if (hashes.serialized !== existingHashes.serialized) {
-    // Only metadata has changed, no need to touch the function.
-    return set_build('serialized_update');
   }
 
   return set_build('none');

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.15.2",
+  "version": "1.15.3",
   "private": true,
   "org": "5qtrs",
   "scripts": {


### PR DESCRIPTION
…y changes the compute settigns

fusebit-api, 1.15.3:

- **Bug fix** Fix a bug in HTTP PUT function API which prevented the effective compute settings of an existing function to be updated if the only change in the function specification was the compute settings.