### PR TITLE
fix #495, fix #374, fix #373: editor fixes

### DIFF
--- a/docs/release-notes/fusebit-editor.md
+++ b/docs/release-notes/fusebit-editor.md
@@ -17,6 +17,14 @@ All public releases of the Fusebit editor are documented here, including notable
 <!-- 1. TOC
 {:toc} -->
 
+## Version 1.3.1
+
+_Released 11/13/19_
+
+- **Bug fix.** Cmd/Ctrl-S correctly saves the function regardless of which editor element is in focus.
+- **Bug fix.** While the function is saving, the editor remains fully functional except for running or saving the function again.
+- **Bug fix.** Newly created functions will have a default configuration, compute, and scheduler settings populated with inline documentation.
+
 ## Version 1.3.0
 
 _Released 11/15/19_

--- a/docs/release-notes/release-notes.md
+++ b/docs/release-notes/release-notes.md
@@ -32,7 +32,7 @@ Fusebit Ops CLI <code>v1.21+</code> - <a href="{{ site.baseurl }}{% link release
 <td style="width:30%">
 <dl>
   <dt>Last updated</dt>
-  <dd>4/14/2020</dd>
+  <dd>5/13/2020</dd>
   <dt>LTS release</dt>
   <dd>No</dd>
 </dl>

--- a/lib/client/fusebit-editor/package.json
+++ b/lib/client/fusebit-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/fusebit-editor",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "main": "libm/index.js",
   "browser": "libm/index.js",

--- a/lib/client/fusebit-editor/src/CreateActionPanel.ts
+++ b/lib/client/fusebit-editor/src/CreateActionPanel.ts
@@ -80,7 +80,7 @@ export function createActionPanel(
     hideNavLogsElement.addEventListener('click', e => {
       e.preventDefault();
       hideNavLogsElement.style.display = 'none';
-      delete showNavLogsElement.style.display;
+      showNavLogsElement.style.display = 'unset';
       editorContext.updateLogsState(false);
       editorContext.updateNavState(false);
     });
@@ -88,7 +88,7 @@ export function createActionPanel(
   showNavLogsElement &&
     showNavLogsElement.addEventListener('click', e => {
       e.preventDefault();
-      delete hideNavLogsElement.style.display;
+      hideNavLogsElement.style.display = 'unset';
       showNavLogsElement.style.display = 'none';
       editorContext.updateLogsState(true);
       editorContext.updateNavState(true);
@@ -98,14 +98,14 @@ export function createActionPanel(
     expandElement.addEventListener('click', e => {
       e.preventDefault();
       expandElement.style.display = 'none';
-      delete compressElement.style.display;
+      compressElement.style.display = 'unset';
       editorContext.setFullScreen(true);
     });
 
   compressElement &&
     compressElement.addEventListener('click', e => {
       e.preventDefault();
-      delete expandElement.style.display;
+      expandElement.style.display = 'unset';
       compressElement.style.display = 'none';
       editorContext.setFullScreen(false);
     });

--- a/lib/client/fusebit-editor/src/CreateEditor.ts
+++ b/lib/client/fusebit-editor/src/CreateEditor.ts
@@ -81,16 +81,16 @@ export function createEditor(
         'light'} fusebit-shell"><div id="${idPrefix}-main" class="fusebit-main">`,
     ];
     if (opts.actionPanel !== false) {
-      lines.push(`<div id="${actionId}" class="fusebit-action-container"></div>`);
+      lines.push(`<div id="${actionId}" class="fusebit-action-container" tabindex="-1"></div>`);
     }
     if (opts.navigationPanel !== false) {
-      lines.push(`<div class="fusebit-nav-container" id="${navId}"></div>`);
+      lines.push(`<div class="fusebit-nav-container" id="${navId}" tabindex="-1"></div>`);
     }
     if (opts.navigationPanel !== false && (opts.editorPanel !== false || opts.logsPanel !== false)) {
-      lines.push(`<div class="fusebit-nav-splitter" id="${navSplitterId}"></div>`);
+      lines.push(`<div class="fusebit-nav-splitter" id="${navSplitterId}" tabindex="-1"></div>`);
     }
     if (opts.editorPanel !== false || opts.logsPanel !== false) {
-      lines.push(`<div class="fusebit-nav-editor-container" id="${navEditorContainerId}">`);
+      lines.push(`<div class="fusebit-nav-editor-container" id="${navEditorContainerId}" tabindex="-1">`);
       if (opts.editorPanel !== false) {
         lines.push(`<div class="fusebit-editor-container" id="${editorId}"></div>`);
       }
@@ -104,7 +104,7 @@ export function createEditor(
     }
     lines.push('</div>');
     if (opts.statusPanel !== false) {
-      lines.push(`<div class="fusebit-status-container" id="${statusId}"></div>`);
+      lines.push(`<div class="fusebit-status-container" id="${statusId}" tabindex="-1"></div>`);
     }
     lines.push('</div>');
 
@@ -199,9 +199,9 @@ export function createEditor(
 
     editorContext.on(Events.Events.LogsStateChanged, (e: Events.LogsStateChangedEvent) => {
       if (e.newState) {
-        delete logsElement.style.display;
+        logsElement.style.display = 'unset';
         if (logsSplitterElement) {
-          delete logsSplitterElement.style.display;
+          logsSplitterElement.style.display = 'unset';
         }
       } else {
         logsElement.style.display = 'none';
@@ -213,9 +213,9 @@ export function createEditor(
 
     editorContext.on(Events.Events.NavStateChanged, (e: Events.NavStateChangedEvent) => {
       if (e.newState) {
-        delete navElement.style.display;
+        navElement.style.display = 'unset';
         if (navSplitterElement) {
-          delete navSplitterElement.style.display;
+          navSplitterElement.style.display = 'unset';
         }
       } else {
         navElement.style.display = 'none';

--- a/lib/client/fusebit-editor/src/CreateEditorPanel.ts
+++ b/lib/client/fusebit-editor/src/CreateEditorPanel.ts
@@ -76,7 +76,7 @@ export function createEditorPanel(element: HTMLElement, editorContext: EditorCon
       Assert.fail('Model or language cannot be determined for the selected file.');
     }
     restoreViewState(activeCategory, editedFileName);
-    delete element.style.display;
+    element.style.display = 'unset';
   });
 
   // When the edited file is deleted, hide the editor
@@ -100,7 +100,7 @@ export function createEditorPanel(element: HTMLElement, editorContext: EditorCon
       Assert.fail('Model cannot be determined the runner script.');
     }
     restoreViewState(activeCategory);
-    delete element.style.display;
+    element.style.display = 'unset';
   });
 
   // When compute settings are selected, serialize them and display as INI for editing
@@ -116,7 +116,7 @@ export function createEditorPanel(element: HTMLElement, editorContext: EditorCon
       Assert.fail('Model cannot be determined for compute node.');
     }
     restoreViewState(activeCategory);
-    delete element.style.display;
+    element.style.display = 'unset';
   });
 
   // When configuration settings are selected, serialize them and display as INI for editing
@@ -132,7 +132,7 @@ export function createEditorPanel(element: HTMLElement, editorContext: EditorCon
       Assert.fail('Model cannot be determined for Configuration settings node.');
     }
     restoreViewState(activeCategory);
-    delete element.style.display;
+    element.style.display = 'unset';
   });
 
   // When schedule settings are selected, serialize them and display as INI for editing
@@ -148,7 +148,7 @@ export function createEditorPanel(element: HTMLElement, editorContext: EditorCon
       Assert.fail('Model cannot be determined for Schedule settings node.');
     }
     restoreViewState(activeCategory);
-    delete element.style.display;
+    element.style.display = 'unset';
   });
 
   editor.onDidChangeModelContent(() => {

--- a/lib/client/fusebit-editor/src/CreateNavigationPanel.ts
+++ b/lib/client/fusebit-editor/src/CreateNavigationPanel.ts
@@ -160,7 +160,7 @@ export function createNavigationPanel(
   let newFileElement = document.getElementById(newFileId) as HTMLElement;
   function addButtonClicked(e: Event) {
     e.preventDefault();
-    delete newFileElement.style.display;
+    newFileElement.style.display = 'unset';
     newFileNameElement.value = '';
     newFileNameElement.focus();
     detectClickOutsideElement(

--- a/lib/client/fusebit-editor/src/EditorContext.ts
+++ b/lib/client/fusebit-editor/src/EditorContext.ts
@@ -26,7 +26,8 @@ const SettingsConfigurationPlaceholder = `# Configuration settings are available
 const SettingsComputePlaceholder = `# Compute settings control resources available to the executing function
 
 # memorySize=128
-# timeout=30`;
+# timeout=30
+# staticIp=false`;
 
 const SettingsCronPlaceholder = `# Set the 'cron' value to execute this function on a schedule
 
@@ -140,6 +141,15 @@ export class EditorContext extends EventEmitter {
         },
       };
     }
+    if (!this.functionSpecification.computeSerialized) {
+      this.functionSpecification.computeSerialized = SettingsComputePlaceholder;
+    }
+    if (!this.functionSpecification.configurationSerialized) {
+      this.functionSpecification.configurationSerialized = SettingsConfigurationPlaceholder;
+    }
+    if (!this.functionSpecification.scheduleSerialized) {
+      this.functionSpecification.scheduleSerialized = SettingsCronPlaceholder;
+    }
     if (!this._ensureFusebitMetadata().runner) {
       this._ensureFusebitMetadata(true).runner = RunnerPlaceholder;
     }
@@ -219,7 +229,6 @@ export class EditorContext extends EventEmitter {
    * Navigates to the Configuration Settings view.
    */
   public selectSettingsConfiguration() {
-    this._ensureWritable();
     this.selectedFileName = undefined;
     const event = new Events.SettingsConfigurationSelectedEvent();
     this.emit(event);
@@ -230,7 +239,6 @@ export class EditorContext extends EventEmitter {
    * @ignore
    */
   public selectSettingsCompute() {
-    this._ensureWritable();
     this.selectedFileName = undefined;
     const event = new Events.SettingsComputeSelectedEvent();
     this.emit(event);
@@ -240,7 +248,6 @@ export class EditorContext extends EventEmitter {
    * Navigates to the Schedule view.
    */
   public selectSettingsSchedule() {
-    this._ensureWritable();
     this.selectedFileName = undefined;
     const event = new Events.SettingsScheduleSelectedEvent();
     this.emit(event);
@@ -250,7 +257,6 @@ export class EditorContext extends EventEmitter {
    * Navigates to the Runner view.
    */
   public selectToolsRunner() {
-    this._ensureWritable();
     this.selectedFileName = undefined;
     const event = new Events.RunnerSelectedEvent();
     this.emit(event);
@@ -261,7 +267,6 @@ export class EditorContext extends EventEmitter {
    * @ignore
    */
   public addFile(fileName: string) {
-    this._ensureWritable();
     if (!this.functionSpecification.nodejs) {
       this.functionSpecification.nodejs = { files: {} };
     }
@@ -285,7 +290,6 @@ export class EditorContext extends EventEmitter {
    * @ignore
    */
   public deleteFile(fileName: string) {
-    this._ensureWritable();
     if (!this.functionSpecification.nodejs || !this.functionSpecification.nodejs.files[fileName]) {
       throw new Error(`File ${fileName} does not exist.`);
     }
@@ -303,7 +307,6 @@ export class EditorContext extends EventEmitter {
    * @param fileName The name of the file to edit.
    */
   public selectFile(fileName: string) {
-    this._ensureWritable();
     if (fileName === this.selectedFileName) {
       return;
     }
@@ -320,7 +323,6 @@ export class EditorContext extends EventEmitter {
    * @ignore
    */
   public setSelectedFileContent(content: string) {
-    this._ensureWritable();
     if (!this.selectedFileName || !this.functionSpecification.nodejs) {
       throw new Error('Cannot set selected file content because no file is selected.');
     }
@@ -333,7 +335,6 @@ export class EditorContext extends EventEmitter {
    * @ignore
    */
   public setRunnerContent(content: string) {
-    this._ensureWritable();
     this._ensureFusebitMetadata(true).runner = content;
     this.setDirtyState(true);
   }
@@ -343,7 +344,6 @@ export class EditorContext extends EventEmitter {
    * @ignore
    */
   public setDirtyState(state: boolean) {
-    this._ensureWritable();
     if (this.dirtyState !== state) {
       this.dirtyState = state;
       const event = new Events.DirtyStateChangedEvent(state);
@@ -356,7 +356,6 @@ export class EditorContext extends EventEmitter {
    * @ignore
    */
   public setSettingsCompute(settings: string) {
-    this._ensureWritable();
     const isDirty = !this.dirtyState && this.functionSpecification.computeSerialized !== settings;
     this.functionSpecification.computeSerialized = settings;
     if (isDirty) {
@@ -369,7 +368,6 @@ export class EditorContext extends EventEmitter {
    * @ignore
    */
   public setSettingsConfiguration(settings: string) {
-    this._ensureWritable();
     const isDirty = !this.dirtyState && this.functionSpecification.configurationSerialized !== settings;
     this.functionSpecification.configurationSerialized = settings;
     if (isDirty) {
@@ -382,7 +380,6 @@ export class EditorContext extends EventEmitter {
    * @ignore
    */
   public setSettingsSchedule(settings: string) {
-    this._ensureWritable();
     const isDirty = !this.dirtyState && this.functionSpecification.scheduleSerialized !== settings;
     this.functionSpecification.scheduleSerialized = settings;
     if (isDirty) {

--- a/lib/client/fusebit-editor/src/fusebit-dark.css
+++ b/lib/client/fusebit-editor/src/fusebit-dark.css
@@ -25,6 +25,7 @@
   align-items: stretch;
   min-height: 100px;
   overflow: hidden;
+  outline: none;
 }
 
 .fusebit-theme-dark .fusebit-logs-splitter {
@@ -41,6 +42,7 @@
   min-height: 100px;
   background-color: #252526;
   position: relative;
+  outline: none;
 }
 
 .fusebit-theme-dark .fusebit-nav-splitter {
@@ -50,6 +52,7 @@
   background: #252526;
   min-height: 100px;
   cursor: col-resize;
+  outline: none;
 }
 
 .fusebit-theme-dark .fusebit-editor-container {
@@ -69,6 +72,7 @@
   overflow: hidden;
   padding-left: 10px;
   padding-top: 10px;
+  outline: false;
 }
 
 .fusebit-theme-dark .fusebit-status-container {
@@ -76,6 +80,7 @@
   font-family: Helvetica, Arial, sans-serif;
   color: #c1c1c1;
   background-color: #383838;
+  outline: none;
 }
 
 .fusebit-theme-dark .fusebit-nav {
@@ -255,6 +260,7 @@
   color: #adadad;
   width: 100px;
   background-color: #333333;
+  outline: none;
 }
 
 .fusebit-theme-dark .fusebit-action-btn {

--- a/lib/client/fusebit-editor/src/fusebit-light.css
+++ b/lib/client/fusebit-editor/src/fusebit-light.css
@@ -25,6 +25,7 @@
   align-items: stretch;
   min-height: 100px;
   overflow: hidden;
+  outline: none;
 }
 
 .fusebit-theme-light .fusebit-logs-splitter {
@@ -41,6 +42,7 @@
   min-height: 100px;
   background-color: #f7f9f9;
   position: relative;
+  outline: none;
 }
 
 .fusebit-theme-light .fusebit-nav-splitter {
@@ -50,6 +52,7 @@
   background: white;
   min-height: 100px;
   cursor: col-resize;
+  outline: none;
 }
 
 .fusebit-theme-light .fusebit-editor-container {
@@ -69,6 +72,7 @@
   overflow: hidden;
   padding-left: 10px;
   padding-top: 10px;
+  outline: false;
 }
 
 .fusebit-theme-light .fusebit-status-container {
@@ -76,6 +80,7 @@
   font-family: Helvetica, Arial, sans-serif;
   color: #34495e;
   background-color: #e5e8e8;
+  outline: none;
 }
 
 .fusebit-theme-light .fusebit-nav {
@@ -254,6 +259,7 @@
   color: #34495e;
   width: 100px;
   background-color: #ebedef;
+  outline: none;
 }
 
 .fusebit-theme-light .fusebit-action-btn {


### PR DESCRIPTION
LTS1 fixes:

- **Bug fix.** Cmd/Ctrl-S correctly saves the function regardless of which editor element is in focus.
- **Bug fix.** While the function is saving, the editor remains fully functional except for running or saving the function again.
- **Bug fix.** Newly created functions will have a default configuration, compute, and scheduler settings populated with inline documentation.