### PR TITLE
fixing release dates in documentation

### DIFF
--- a/docs/release-notes/fusebit-editor.md
+++ b/docs/release-notes/fusebit-editor.md
@@ -19,7 +19,7 @@ All public releases of the Fusebit editor are documented here, including notable
 
 ## Version 1.3.1
 
-_Released 11/13/19_
+_Released 5/12/20_
 
 - **Bug fix.** Cmd/Ctrl-S correctly saves the function regardless of which editor element is in focus.
 - **Bug fix.** While the function is saving, the editor remains fully functional except for running or saving the function again.

--- a/docs/release-notes/release-notes.md
+++ b/docs/release-notes/release-notes.md
@@ -32,7 +32,7 @@ Fusebit Ops CLI <code>v1.21+</code> - <a href="{{ site.baseurl }}{% link release
 <td style="width:30%">
 <dl>
   <dt>Last updated</dt>
-  <dd>5/13/2020</dd>
+  <dd>5/12/2020</dd>
   <dt>LTS release</dt>
   <dd>No</dd>
 </dl>


### PR DESCRIPTION
Fixing wrong dates in the release notes for 1.3.1 of the fusebit-editor