### PR TITLE
Fix #411. Increase ALB idle timeout to 120s

### DIFF
--- a/cli/fusebit-ops-cli/package.json
+++ b/cli/fusebit-ops-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/fusebit-ops-cli",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "The Fusebit Platform Operations CLI",
   "main": "libc/index.js",
   "license": "UNLICENSED",

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -6,7 +6,7 @@ nav_exclude: true
 
 # Downloads
 
-_Last updated May 6, 2020_
+_Last updated May 19, 2020_
 
 This page contains download links for the components of the Fusebit platform. A description of our versioning and support policy is available [here](https://fusebit.io/docs/integrator-guide/versioning/).
 

--- a/docs/release-notes/fusebit-ops-cli.md
+++ b/docs/release-notes/fusebit-ops-cli.md
@@ -18,10 +18,11 @@ All public releases of the Fusebit Operations CLI are documented here, including
 {:toc}
 -->
 
-## Version X.X.X
+## Version 1.22.1
 
-_Released X/XX/XX_
+_Released 5/19/20_
 
+- **Idle Timeout Increase.** Increased the default idle timeout of the application load balancer to 120 seconds. For this setting to take effect, please re-run `fuse-ops deployment add` on your deployment.
 - **Input Validation.** Disallow network names that include non-alphanumeric characters.
 
 ## Version 1.21.0

--- a/docs/release-notes/release-notes.md
+++ b/docs/release-notes/release-notes.md
@@ -26,13 +26,13 @@ Fusebit Editor <code>v1.4+</code> - <a href="{{ site.baseurl }}{% link release-n
 Fusebit HTTP API <code>v1.15+</code> - <a href="{{ site.baseurl }}{% link release-notes/fusebit-http-api.md %}">release notes</a>
 </li>
 <li>
-Fusebit Ops CLI <code>v1.21+</code> - <a href="{{ site.baseurl }}{% link release-notes/fusebit-ops-cli.md %}">release notes</a></li>
+Fusebit Ops CLI <code>v1.22+</code> - <a href="{{ site.baseurl }}{% link release-notes/fusebit-ops-cli.md %}">release notes</a></li>
 </ul>
 </td>
 <td style="width:30%">
 <dl>
   <dt>Last updated</dt>
-  <dd>5/14/2020</dd>
+  <dd>5/19/2020</dd>
   <dt>LTS release</dt>
   <dd>No</dd>
 </dl>


### PR DESCRIPTION
- **Idle Timeout Increase.** Increased the default idle timeout of the application load balancer to 120 seconds. For this setting to take effect, please re-run `fuse-ops deployment add` on your deployment.

Verified by reducing idle timeout on stage to 30s, then running `fuse-ops deployment add` on it, which set it back to 120s.