### PR TITLE
Fix cross-region DWH bug

### DIFF
--- a/cli/fusebit-ops-cli/package.json
+++ b/cli/fusebit-ops-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/fusebit-ops-cli",
-  "version": "1.24.2",
+  "version": "1.24.3",
   "description": "The Fusebit Platform Operations CLI",
   "main": "libc/index.js",
   "license": "UNLICENSED",

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -6,7 +6,7 @@ nav_exclude: true
 
 # Downloads
 
-_Last updated June 28, 2020_
+_Last updated August 25, 2020_
 
 This page contains download links for the components of the Fusebit platform. A description of our versioning and support policy is available [here](https://fusebit.io/docs/integrator-guide/versioning/).
 
@@ -22,4 +22,4 @@ This page contains download links for the components of the Fusebit platform. A 
 - Fusebit Portal: `fuse-ops portal deploy`
 - Fusebit HTTP API
   - Cloud deployment - `https://api.{region}.fusebit.io/v1`
-  - Private deployment image - `fuse-ops image pull 1.17.2`
+  - Private deployment image - `fuse-ops image pull 1.17.4`

--- a/docs/release-notes/fusebit-ops-cli.md
+++ b/docs/release-notes/fusebit-ops-cli.md
@@ -18,6 +18,12 @@ All public releases of the Fusebit Operations CLI are documented here, including
 {:toc}
 -->
 
+## Version 1.24.3
+
+_Released 8/25/20_
+
+- **Bugfix.** Fix internal analytics issue with cross-region deployments.
+
 ## Version 1.24.2
 
 _Released 7/17/20_

--- a/docs/release-notes/release-notes.md
+++ b/docs/release-notes/release-notes.md
@@ -35,7 +35,7 @@ Fusebit Ops CLI <code>v1.24+</code> - <a href="{{ site.baseurl }}{% link release
 <td style="width:30%">
 <dl>
   <dt>Last updated</dt>
-  <dd>08/12/2020</dd>
+  <dd>08/25/2020</dd>
   <dt>LTS release</dt>
   <dd>No</dd>
 </dl>

--- a/lib/runtime/lambda-dwh/src/exportAgent.ts
+++ b/lib/runtime/lambda-dwh/src/exportAgent.ts
@@ -1,51 +1,36 @@
 import { IExportConfig, IExportContext, exportDynamoTable } from './utils';
 
 export async function exportAgent(ctx: IExportContext, config: IExportConfig) {
-  await ctx.bq.query(`DELETE FROM \`dwh.agent\` WHERE ts = '${config.ts}' AND deploymentId = '${config.deploymentId}'`);
-  await exportDynamoTable(
-    ctx,
-    config,
-    'client',
-    'agent',
-    (x: any) => {
-      let item: any = {
-        json: {
-          ts: config.ts,
-          deploymentId: config.deploymentId,
-          accountId: x.accountId && x.accountId.S,
-          agentId: x.clientId && x.clientId.S,
-          agentType: 'client',
-          displayName: x.displayName && x.displayName.S,
-          archived: x.archived !== undefined ? x.archived.BOOL : false,
-        },
-      };
-      item.insertId = `${item.json.deploymentId}/${item.json.accountId}/${item.json.agentId}/${item.json.ts}`;
-      return item;
-    },
-    true
-  );
-  return await exportDynamoTable(
-    ctx,
-    config,
-    'user',
-    'agent',
-    (x: any) => {
-      let item: any = {
-        json: {
-          ts: config.ts,
-          deploymentId: config.deploymentId,
-          accountId: x.accountId && x.accountId.S,
-          agentId: x.userId && x.userId.S,
-          agentType: 'user',
-          firstName: x.firstName && x.firstName.S,
-          lastName: x.lastName && x.lastName.S,
-          primaryEmail: x.primaryEmail && x.primaryEmail.S,
-          archived: x.archived !== undefined ? x.archived.BOOL : false,
-        },
-      };
-      item.insertId = `${item.json.deploymentId}/${item.json.accountId}/${item.json.agentId}/${item.json.ts}`;
-      return item;
-    },
-    true
-  );
+  await exportDynamoTable(ctx, config, 'client', 'agent', (x: any) => {
+    let item: any = {
+      json: {
+        ts: config.ts,
+        deploymentId: config.deploymentId,
+        accountId: x.accountId && x.accountId.S,
+        agentId: x.clientId && x.clientId.S,
+        agentType: 'client',
+        displayName: x.displayName && x.displayName.S,
+        archived: x.archived !== undefined ? x.archived.BOOL : false,
+      },
+    };
+    item.insertId = `${item.json.deploymentId}/${item.json.accountId}/${item.json.agentId}/${item.json.ts}`;
+    return item;
+  });
+  return await exportDynamoTable(ctx, config, 'user', 'agent', (x: any) => {
+    let item: any = {
+      json: {
+        ts: config.ts,
+        deploymentId: config.deploymentId,
+        accountId: x.accountId && x.accountId.S,
+        agentId: x.userId && x.userId.S,
+        agentType: 'user',
+        firstName: x.firstName && x.firstName.S,
+        lastName: x.lastName && x.lastName.S,
+        primaryEmail: x.primaryEmail && x.primaryEmail.S,
+        archived: x.archived !== undefined ? x.archived.BOOL : false,
+      },
+    };
+    item.insertId = `${item.json.deploymentId}/${item.json.accountId}/${item.json.agentId}/${item.json.ts}`;
+    return item;
+  });
 }

--- a/lib/runtime/lambda-dwh/src/exportFunction.ts
+++ b/lib/runtime/lambda-dwh/src/exportFunction.ts
@@ -19,9 +19,6 @@ export async function exportFunction(ctx: IExportContext, config: IExportConfig)
   cronJobList.forEach((x) => {
     cronJobs[`${x.subscriptionId}/${x.boundaryId}/${x.functionId}`] = x;
   });
-  await ctx.bq.query(
-    `DELETE FROM \`dwh.function\` WHERE ts = '${config.ts}' AND deploymentId = '${config.deploymentId}'`
-  );
   await exportFunctionCore();
 
   return;

--- a/lib/runtime/lambda-dwh/src/utils.ts
+++ b/lib/runtime/lambda-dwh/src/utils.ts
@@ -36,7 +36,6 @@ export async function bqInsert(ctx: IExportContext, table: string, payload: any[
       .catch((e: any) => {
         console.log(`ERROR inserting ${payload.length} records to dwh.${table} table in Big Query`, e.message);
         console.log('ERROR[0]', e.errors ? JSON.stringify(e.errors[0], null, 2) : 'NA');
-        throw e;
       })
   );
 }
@@ -46,14 +45,8 @@ export async function exportDynamoTable(
   config: IExportConfig,
   dynamoTable: string,
   bqTable: string,
-  itemMapper: (x: any) => any,
-  skipDelete?: boolean
+  itemMapper: (x: any) => any
 ) {
-  if (!skipDelete) {
-    await ctx.bq.query(
-      `DELETE FROM \`dwh.${dynamoTable}\` WHERE ts = '${config.ts}' AND deploymentId = '${config.deploymentId}'`
-    );
-  }
   await exportDynamoTableCore();
 
   return;


### PR DESCRIPTION
High level: fixing DWH so that we know what Hyperproof is doing in us-west-1. 

This fixes two issues in the DWH lambda associated with a Fusebit deployment and responsible for taking the daily snapshot of deployment data in BigQuery:

1. If we have identically named deployments (e.g. `api`) in two or more regions of AWS, they will clobber each other's data in DWH, since the logic currently removes all data for a (deployment, day) from BQ before inserting. 

2. Given how BQ is implemented, the delete and insert operations will likely conflict and fail if not separated by at least 90 minutes and if the delete operation actually deletes something. This issue only started manifesting itself only after we added a second `api` deployment in us-west-1, since only since then the delete on bigquery actually attempted to delete something (related to 1 above). 

The fix is to remove the delete step from the DWH lambda. It was originally added to facilitate development of the DWH lambda (start from a clean slate). Turns out that the BQ insert operation is smart enough not to add duplicate rows, which is really all we care about in case the lambda needs to be manually re-run. 