### PR TITLE
Portal: support for  per-subscription integration tiles in the integr…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ typings/
 
 # Yarn Integrity file
 .yarn-integrity
+.yarn
+.yarnrc
 
 # dotenv environment variables file
 .env

--- a/site/portal/package.json
+++ b/site/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/portal",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Fusebit Portal",
   "private": true,
   "dependencies": {

--- a/site/portal/public/config.json
+++ b/site/portal/public/config.json
@@ -20,23 +20,6 @@
           }
         },
         {
-          "id": "stage-us-portal-demo",
-          "displayName": "Demo",
-          "icon": "https://cdn.fusebit.io/assets/images/us.png",
-          "baseUrl": "https://stage.us-west-2.fusebit.io",
-          "account": "acc-9d9341ea356841ed",
-          "subscription": "sub-9cc617a5489142f0",
-          "catalog": "https://stage.us-west-2.fusebit.io/v1/run/sub-9cc617a5489142f0/internal/config",
-          "oauth": {
-            "webAuthorizationUrl": "https://fusebit.auth0.com/authorize",
-            "webClientId": "hSgWIXmbluQMADuWhDnRTpWyKptJe6LB",
-            "webLogoutUrl": "https://fusebit.auth0.com/v2/logout?client_id=hSgWIXmbluQMADuWhDnRTpWyKptJe6LB&returnTo=https://portal.fusebit.io",
-            "deviceAuthorizationUrl": "https://fusebit.auth0.com/oauth/device/code",
-            "deviceClientId": "VFOtrBCVHEm7I9UNv7rFwu1ID1hTEueF",
-            "tokenUrl": "https://fusebit.auth0.com/oauth/token"
-          }
-        },
-        {
           "id": "stage-eu-portal-dev",
           "displayName": "Stage EU (portal-dev)",
           "icon": "https://cdn.fusebit.io/assets/images/eu.png",

--- a/site/portal/src/components/NewFunction.tsx
+++ b/site/portal/src/components/NewFunction.tsx
@@ -112,15 +112,18 @@ function NewFunction({ subscriptionId, boundaryId }: any) {
     window.location.href = url;
   };
 
+  // Only show templates that:
+  // 1. are applicable to all subscriptions or are enabled for this subscription, and
+  // 2. match the user-specified filter, if any
   const filter = search.trim().toLowerCase();
-  const templates = filter
-    ? catalog.existing.templates.reduce((previous: CatalogTemplate[], current: CatalogTemplate) => {
-        if (current.name.toLowerCase().indexOf(filter) > -1 || current.description.toLowerCase().indexOf(filter) > -1) {
-          previous.push(current);
-        }
-        return previous;
-      }, [])
-    : catalog.existing.templates;
+  const templates = catalog.existing.templates.filter(
+    (template: CatalogTemplate) =>
+      (!template.enabledSubscriptions || template.enabledSubscriptions.indexOf(subscriptionId) > -1) &&
+      (!filter ||
+        template.name.toLowerCase().indexOf(filter) > -1 ||
+        template.description.toLowerCase().indexOf(filter) > -1 ||
+        (template.tags && template.tags.find((tag: string) => tag.toLowerCase().indexOf(filter) > -1)))
+  );
 
   return (
     <React.Fragment>

--- a/site/portal/src/lib/CatalogTypes.ts
+++ b/site/portal/src/lib/CatalogTypes.ts
@@ -6,6 +6,7 @@ export type CatalogTemplate = {
   icon?: string;
   managerUrl: string;
   documentationUrl?: string;
+  enabledSubscriptions?: string[];
 };
 
 export type Catalog = {
@@ -77,6 +78,16 @@ export function parseCatalog(data: any): Catalog {
       t.tags.forEach((e: any) => {
         if (typeof e !== 'string') {
           throw new Error(`The 'tags' property of a template must only contain strings.`);
+        }
+      });
+    }
+    if (t.enabledSubscriptions && !Array.isArray(t.enabledSubscriptions)) {
+      throw new Error(`The 'enabledSubscriptions' property of a template, if specified, must be an array of strings.`);
+    }
+    if (t.enabledSubscriptions) {
+      t.enabledSubscriptions.forEach((e: any) => {
+        if (typeof e !== 'string') {
+          throw new Error(`The 'enabledSubscriptions' property of a template must only contain strings.`);
         }
       });
     }


### PR DESCRIPTION
…ation gallery

This is something Aaron asked for, but also something we can use to have distinct integration tiles in the stage and demo subscriptions *without* forcing us to have distinct profiles in the portal. You can now specify `enabledSubscriptions` array as part of the template definition: 

```json
    {
      "id": "empty", 
      "name": "Empty Function",
      "description": "Full flexibility with Node.js and npm",
      "tags": [],
      "managerUrl": "https://stage.us-west-2.fusebit.io/v1/run/sub-ed9d9341ea356841/template-manager/empty",
      "documentationUrl": "https://github.com/fusebit/samples",
      "enabledSubscriptions": ["sub-ed9d9341ea356841"]
    },
```

The tile will show up in the gallery if the `enabledSubscriptions` is missing, or if it contains the ID of the current subscription. 