### PR TITLE
Update the ES schema to allow objects for req.header.authorization

### DIFF
--- a/api/function-api/src/routes/handlers/elastic_template.js
+++ b/api/function-api/src/routes/handlers/elastic_template.js
@@ -984,15 +984,6 @@ const fusebitTemplate = {
                   },
                 },
               },
-              authorization: {
-                type: 'text',
-                fields: {
-                  keyword: {
-                    type: 'keyword',
-                    ignore_above: 256,
-                  },
-                },
-              },
               'cache-control': {
                 type: 'text',
                 fields: {

--- a/cli/fusebit-ops-cli/package.json
+++ b/cli/fusebit-ops-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/fusebit-ops-cli",
-  "version": "1.24.13",
+  "version": "1.24.14",
   "description": "The Fusebit Platform Operations CLI",
   "main": "libc/index.js",
   "license": "UNLICENSED",

--- a/docs/release-notes/fusebit-http-api.md
+++ b/docs/release-notes/fusebit-http-api.md
@@ -17,6 +17,12 @@ All public releases of the Fusebit HTTP API are documented here, including notab
 <!-- 1. TOC
 {:toc} -->
 
+## Version 1.18.11
+
+_Released 12/14/20_
+
+- **Bugfix.** Resolve ES schema confusion around analytics record schema for the JWT access credentials.
+
 ## Version 1.18.10
 
 _Released 12/11/20_

--- a/docs/release-notes/fusebit-ops-cli.md
+++ b/docs/release-notes/fusebit-ops-cli.md
@@ -18,6 +18,12 @@ All public releases of the Fusebit Operations CLI are documented here, including
 {:toc}
 -->
 
+## Version 1.24.14
+
+_Released 12/14/20_
+
+- **Bugfix.** Resolve ES schema confusion around analytics record schema for the JWT access credentials.
+
 ## Version 1.24.13
 
 _Released 12/11/20_

--- a/lib/runtime/common/src/analytics.js
+++ b/lib/runtime/common/src/analytics.js
@@ -37,7 +37,7 @@ const dissect_trace = (error) => {
 const extractJwt = (jwt) => {
   const token = decodeJwt(jwt, false, true);
   if (!token) {
-    return '__INVALID_JWT__';
+    return { status: '__INVALID_JWT__' };
   }
 
   return { header: token.header, payload: token.payload };
@@ -73,7 +73,7 @@ exports.dispatch_event = (e) => {
       const token = ev.request.headers.authorization.match(/^bearer +(.*)$/i)[1];
       ev.request.headers.authorization = extractJwt(token);
     } else {
-      ev.request.headers.authorization = '__PRESENT__';
+      ev.request.headers.authorization = { status: '__PRESENT__' };
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.18.10",
+  "version": "1.18.11",
   "private": true,
   "org": "5qtrs",
   "engines": {


### PR DESCRIPTION
Removing the schema entry allows ES to "discover" what the schema should be.  This will be paired with an ES backend wipe to eliminate any confusing records against the index for this month.