### PR TITLE
Normalize the fusebit-ops-cli to always use --output,-o

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,3 @@
-
 on: workflow_dispatch
 
 name: Build the package
@@ -9,14 +8,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
         node-version: '10.15.3'
 
+    ###########################################################################
+    # Turn on system level caching
     - name: Cache Node.js modules
       uses: actions/cache@v2
       with:
@@ -24,23 +22,160 @@ jobs:
         path: ~/.npm
         key: ${{ runner.OS }}-node
 
-    - name: Pin Yarn Version
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+
+    - name: Cache yarn modules
+      uses: actions/cache@v2
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    ###########################################################################
+    # Checkout the repository
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    ###########################################################################
+    # Acquire the version of the various packages
+    - name: Version - function-api
+      id: version-function-api
+      run: |
+        export VERSION_FUNCTION_API=`jq -r '.version' ./package.json`
+        echo "::set-output name=version-function-api::${VERSION_FUNCTION_API}"
+        echo "VERSION_FUNCTION_API=${VERSION_FUNCTION_API}" >> $GITHUB_ENV
+
+    - name: Version - fusebit-cli
+      id: version-fusebit-cli
+      run: |
+        export VERSION_FUSEBIT_CLI=`jq -r '.version' ./cli/fusebit-cli/package.json`
+        echo "::set-output name=version-fusebit-cli::${VERSION_FUSEBIT_CLI}"
+        echo "VERSION_FUSEBIT_CLI=${VERSION_FUSEBIT_CLI}" >> $GITHUB_ENV
+
+    - name: Version - fusebit-ops-cli
+      id: version-fusebit-ops-cli
+      run: |
+        export VERSION_FUSEBIT_OPS_CLI=`jq -r '.version' ./cli/fusebit-ops-cli/package.json`
+        echo "::set-output name=version-fusebit-ops-cli::${VERSION_FUSEBIT_OPS_CLI}"
+        echo "VERSION_FUSEBIT_OPS_CLI=${VERSION_FUSEBIT_OPS_CLI}" >> $GITHUB_ENV
+
+    ###########################################################################
+    # Create the settings and profile files expected for a functioning environment
+    - name: Setup - function-api/.env
+      env:
+        dotenv: api/function-api/.env
+      run: |
+        echo DEPLOYMENT_KEY=stage > ${dotenv}.template
+        echo AWS_REGION=us-west-2 >> ${dotenv}.template
+        echo API_SERVER=https://stage.us-west-2.fusebit.io >> ${dotenv}.template
+        echo > ${dotenv}.bootstrap
+
+    - name: Setup - fuse profile
+      env:
+        SECRET_FUSEBIT_PROFILE: ${{secrets.FUSEBIT_STAGE_US_WEST_2}}
+      run: |
+        export FUSEBIT_KEYPATH=`echo ${SECRET_FUSEBIT_PROFILE} | jq -r '.user.keyPath'`
+        mkdir -p ~/.fusebit/${FUSEBIT_KEYPATH}
+        echo ${SECRET_FUSEBIT_PROFILE} | jq -r '.user.settings' > ~/.fusebit/settings.json
+        echo ${SECRET_FUSEBIT_PROFILE} | jq -r '.user.keys.privateKey' > ~/.fusebit/${FUSEBIT_KEYPATH}/pri
+        echo ${SECRET_FUSEBIT_PROFILE} | jq -r '.user.keys.publicKey' > ~/.fusebit/${FUSEBIT_KEYPATH}/pub
+
+    - name: Setup - fuse-ops profile
+      env:
+        SECRET_FUSEBIT_PROFILE: ${{secrets.FUSEBIT_STAGE_US_WEST_2}}
+      run: |
+        mkdir -p ~/.fusebit-ops
+        echo ${SECRET_FUSEBIT_PROFILE} | jq -r '.ops.settings' > ~/.fusebit-ops/settings.json
+
+    - name: Setup - AWS credentials
+      env:
+        SECRET_FUSEBIT_PROFILE: ${{secrets.FUSEBIT_STAGE_US_WEST_2}}
+      run: |
+        mkdir ~/.aws
+        echo "[default]" > ~/.aws/config
+        echo "region = us-west-2" >> ~/.aws/config
+
+        OPS_PROFILE_NAME=`echo ${SECRET_FUSEBIT_PROFILE} | jq -r '.ops.profileName'`
+        OPS_PROFILE=`echo ${SECRET_FUSEBIT_PROFILE} | jq -r '.ops.settings.profiles["'${OPS_PROFILE_NAME}'"]'`
+        echo "[default]" > ~/.aws/credentials
+        echo "aws_access_key_id = `echo ${OPS_PROFILE} | jq -r '.awsAccessKeyId'`" >> ~/.aws/credentials
+        echo "aws_secret_access_key = `echo ${OPS_PROFILE} | jq -r '.awsSecretAccessKey'`" >> ~/.aws/credentials
+
+    - name: Setup - npm credentials
+      env:
+        SECRET_NPM_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}
+      run: |
+        echo //registry.npmjs.org/:_authToken=${SECRET_NPM_TOKEN} > ~/.npmrc
+
+    - name: Setup - deployment .env
+      env:
+        FUSEBIT_GC_BQ_KEY_BASE64: ${{secrets.FUSEBIT_GC_BQ_KEY_BASE64}}
+      run: echo FUSEBIT_GC_BQ_KEY_BASE64=${FUSEBIT_GC_BQ_KEY_BASE64} > gc_bq.env
+
+    - name: Qualify - aws-cli works
+      run: aws s3 ls
+
+    - name: Qualify - npm works
+      run: npm whoami
+
+    ###########################################################################
+    # Build the tree
+    - name: Pre-Build Summary
+      run: |
+        echo function-api: ${VERSION_FUNCTION_API}
+        echo fusebit-cli: ${VERSION_FUSEBIT_CLI}
+        echo fusebit-ops-cli: ${VERSION_FUSEBIT_OPS_CLI}
+
+    - name: Yarn - pin version
       run: yarn set version 1.21.1
-      
-    - name: Setup Yarn
+
+    - name: Yarn - setup
       run: yarn --frozen-lockfile setup
 
-    - name: Install dependencies
+    - name: Yarn - install
       run: yarn --frozen-lockfile install
-      
-    - name: Build Tree
+
+    - name: Yarn - build
       run: yarn build
-  
-    - name: Populate Fusebit Profile
-      run: mkdir -p ~/.fusebit/`cat ${FUSEBIT_STAGE_US_WEST_2} | jq -r '.keyPath'`
-    - run: cat ${FUSEBIT_STAGE_US_WEST_2} | jq -r '.privateKey' > ~/.fusebit/`cat ${FUSEBIT_STAGE_US_WEST_2} | jq -r '.keyPath'`/pri
-    - run: cat ${FUSEBIT_STAGE_US_WEST_2} | jq -r '.publicKey' > ~/.fusebit/`cat ${FUSEBIT_STAGE_US_WEST_2} | jq -r '.keyPath'`/pub
-    - run: cat ${FUSEBIT_STAGE_US_WEST_2} | jq -r '.settings' > ~/.fusebit/settings.json
-    
-    - name: Test Fuse Function ls
+
+    ###########################################################################
+    # Qualify that the tools work as expected
+    - name: Qualify - fuse-ops works
+      run: node cli/fusebit-ops-cli/libc/index.js stack ls
+
+    - name: Qualify - fuse works
       run: node cli/fusebit-cli/libc/index.js function ls
+
+    ###########################################################################
+    # Publish various artifacts
+    - name: Yarn - image
+      run: yarn image
+
+    - name: Publish - function-api
+      run: ./tool/cicd/actions/publish_function_api.sh
+
+    - name: Publish - fusebit-ops-cli
+      run: ./tool/cicd/actions/publish_fusebit_ops_cli.sh
+
+    - name: Publish - fusebit-cli
+      run: ./tool/cicd/actions/publish_fusebit_cli.sh
+
+    ###########################################################################
+    # Run automated tests
+    - name: Test - deploy exclusive to stage/us-west-2
+      env:
+        REGION: us-west-2
+        DEPLOYMENT_NAME: stage
+      run: ./tool/cicd/actions/deploy_exclusive_function_api.sh
+
+    - name: Test - function-api
+      env:
+        SECRET_FUSEBIT_PROFILE: ${{secrets.FUSEBIT_STAGE_US_WEST_2}}
+      run: |
+        cd api/function-api
+        export FUSE_PROFILE=`echo ${SECRET_FUSEBIT_PROFILE} | jq -r '.user.profileName'`
+        EC2=1 yarn test

--- a/cli/fusebit-ops-cli/package.json
+++ b/cli/fusebit-ops-cli/package.json
@@ -15,7 +15,8 @@
   "packageAs": "fusebit-ops-cli",
   "packageAssets": [],
   "scripts": {
-    "build": "yarn build:lambdas && tsc -b",
+    "build": "yarn build:lambdas && yarn compile",
+    "compile": "tsc -b",
     "build:lambdas": "cd ../.. && yarn build ops-lambda-set",
     "test": "jest --colors",
     "coverage": "jest --colors --coverage",

--- a/cli/fusebit-ops-cli/src/commands/account/ListAccountCommand.ts
+++ b/cli/fusebit-ops-cli/src/commands/account/ListAccountCommand.ts
@@ -12,10 +12,10 @@ const command = {
   description: 'Lists the accounts in the Fusebit platform.',
   options: [
     {
-      name: 'format',
-      aliases: ['f'],
-      description: "The format to display the output: 'table', 'json'",
-      default: 'table',
+      name: 'output',
+      aliases: ['o'],
+      description: "The format to display the output: 'pretty', 'json'",
+      default: 'pretty',
     },
   ],
 };
@@ -35,11 +35,11 @@ export class ListAccountCommand extends Command {
 
   protected async onExecute(input: IExecuteInput): Promise<number> {
     await input.io.writeLine();
-    const format = input.options.format as string;
+    const output = input.options.output as string;
 
     const accountService = await AccountService.create(input);
 
-    if (format === 'json') {
+    if (output === 'json') {
       const accounts = await accountService.listAllAccounts();
       await accountService.displayAccounts(accounts);
     } else {

--- a/cli/fusebit-ops-cli/src/commands/deployment/ListDeploymentCommand.ts
+++ b/cli/fusebit-ops-cli/src/commands/deployment/ListDeploymentCommand.ts
@@ -12,10 +12,10 @@ const command = {
   description: 'Lists the deployments in the Fusebit platform.',
   options: [
     {
-      name: 'format',
-      aliases: ['f'],
-      description: "The format to display the output: 'table', 'json'",
-      default: 'table',
+      name: 'output',
+      aliases: ['o'],
+      description: "The format to display the output: 'pretty', 'json'",
+      default: 'pretty',
     },
   ],
 };
@@ -36,11 +36,11 @@ export class ListDeploymentCommand extends Command {
   protected async onExecute(input: IExecuteInput): Promise<number> {
     await input.io.writeLine();
 
-    const format = input.options.format as string;
+    const output = input.options.output as string;
 
     const deploymentService = await DeploymentService.create(input);
 
-    if (format === 'json') {
+    if (output === 'json') {
       const accounts = await deploymentService.listAllDeployments();
       await deploymentService.displayDeployments(accounts);
     } else {

--- a/cli/fusebit-ops-cli/src/commands/domain/AddDomainCommand.ts
+++ b/cli/fusebit-ops-cli/src/commands/domain/AddDomainCommand.ts
@@ -29,10 +29,10 @@ const command = {
       default: 'true',
     },
     {
-      name: 'format',
-      aliases: ['f'],
-      description: "The format to display the output: 'table', 'json'",
-      default: 'table',
+      name: 'output',
+      aliases: ['o'],
+      description: "The format to display the output: 'pretty', 'json'",
+      default: 'pretty',
     },
   ],
 };

--- a/cli/fusebit-ops-cli/src/commands/domain/GetDomainCommand.ts
+++ b/cli/fusebit-ops-cli/src/commands/domain/GetDomainCommand.ts
@@ -18,10 +18,10 @@ const command = {
   ],
   options: [
     {
-      name: 'format',
-      aliases: ['f'],
-      description: "The format to display the output: 'table', 'json'",
-      default: 'table',
+      name: 'output',
+      aliases: ['o'],
+      description: "The format to display the output: 'pretty', 'json'",
+      default: 'pretty',
     },
   ],
 };

--- a/cli/fusebit-ops-cli/src/commands/domain/ListDomainCommand.ts
+++ b/cli/fusebit-ops-cli/src/commands/domain/ListDomainCommand.ts
@@ -12,10 +12,10 @@ const command = {
   description: 'Lists the domains in the Fusebit platform.',
   options: [
     {
-      name: 'format',
-      aliases: ['f'],
-      description: "The format to display the output: 'table', 'json'",
-      default: 'table',
+      name: 'output',
+      aliases: ['o'],
+      description: "The format to display the output: 'pretty', 'json'",
+      default: 'pretty',
     },
   ],
 };
@@ -36,11 +36,11 @@ export class ListDomainCommand extends Command {
   protected async onExecute(input: IExecuteInput): Promise<number> {
     await input.io.writeLine();
 
-    const format = input.options.format as string;
+    const output = input.options.output as string;
 
     const domainService = await DomainService.create(input);
 
-    if (format === 'json') {
+    if (output === 'json') {
       const accounts = await domainService.listAllDomains();
       await domainService.displayDomains(accounts);
     } else {

--- a/cli/fusebit-ops-cli/src/commands/network/ListNetworkCommand.ts
+++ b/cli/fusebit-ops-cli/src/commands/network/ListNetworkCommand.ts
@@ -12,10 +12,10 @@ const command = {
   description: 'Lists the networks in the Fusebit platform.',
   options: [
     {
-      name: 'format',
-      aliases: ['f'],
-      description: "The format to display the output: 'table', 'json'",
-      default: 'table',
+      name: 'output',
+      aliases: ['o'],
+      description: "The format to display the output: 'pretty', 'json'",
+      default: 'pretty',
     },
   ],
 };
@@ -36,11 +36,11 @@ export class ListNetworkCommand extends Command {
   protected async onExecute(input: IExecuteInput): Promise<number> {
     await input.io.writeLine();
 
-    const format = input.options.format as string;
+    const output = input.options.output as string;
 
     const networkService = await NetworkService.create(input);
 
-    if (format === 'json') {
+    if (output === 'json') {
       const accounts = await networkService.listAllNetworks();
       await networkService.displayNetworks(accounts);
     } else {

--- a/cli/fusebit-ops-cli/src/commands/portal/DeployPortalCommand.ts
+++ b/cli/fusebit-ops-cli/src/commands/portal/DeployPortalCommand.ts
@@ -39,10 +39,10 @@ const command = {
       default: 'true',
     },
     {
-      name: 'format',
-      aliases: ['f'],
-      description: "The format to display the output: 'table', 'json'",
-      default: 'table',
+      name: 'output',
+      aliases: ['o'],
+      description: "The format to display the output: 'pretty', 'json'",
+      default: 'pretty',
     },
   ],
 };

--- a/cli/fusebit-ops-cli/src/commands/portal/ListPortalCommand.ts
+++ b/cli/fusebit-ops-cli/src/commands/portal/ListPortalCommand.ts
@@ -12,10 +12,10 @@ const command = {
   description: 'Lists existing Fusebit Portals.',
   options: [
     {
-      name: 'format',
-      aliases: ['f'],
-      description: "The format to display the output: 'table', 'json'",
-      default: 'table',
+      name: 'output',
+      aliases: ['o'],
+      description: "The format to display the output: 'pretty', 'json'",
+      default: 'pretty',
     },
   ],
 };

--- a/cli/fusebit-ops-cli/src/commands/profile/ProfileCopyCommand.ts
+++ b/cli/fusebit-ops-cli/src/commands/profile/ProfileCopyCommand.ts
@@ -32,9 +32,10 @@ const command = {
       default: 'true',
     },
     {
-      name: 'format',
-      description: "The format to display the output: 'table', 'json'",
-      default: 'table',
+      name: 'output',
+      aliases: ['o'],
+      description: "The format to display the output: 'pretty', 'json'",
+      default: 'pretty',
     },
   ],
 };

--- a/cli/fusebit-ops-cli/src/commands/profile/ProfileDefaultCommand.ts
+++ b/cli/fusebit-ops-cli/src/commands/profile/ProfileDefaultCommand.ts
@@ -24,9 +24,10 @@ const command = {
       required: false,
     },
     {
-      name: 'format',
-      description: "The format to display the output: 'table', 'json'",
-      default: 'table',
+      name: 'output',
+      aliases: ['o'],
+      description: "The format to display the output: 'pretty', 'json'",
+      default: 'pretty',
     },
   ],
 };

--- a/cli/fusebit-ops-cli/src/commands/profile/ProfileListCommand.ts
+++ b/cli/fusebit-ops-cli/src/commands/profile/ProfileListCommand.ts
@@ -18,9 +18,10 @@ const command = {
       description: 'Only list profiles with the given text in the profile name',
     },
     {
-      name: 'format',
-      description: "The format to display the output: 'table', 'json'",
-      default: 'table',
+      name: 'output',
+      aliases: ['o'],
+      description: "The format to display the output: 'pretty', 'json'",
+      default: 'pretty',
     },
   ],
 };

--- a/cli/fusebit-ops-cli/src/commands/profile/ProfileRenameCommand.ts
+++ b/cli/fusebit-ops-cli/src/commands/profile/ProfileRenameCommand.ts
@@ -29,9 +29,10 @@ const command = {
       default: 'true',
     },
     {
-      name: 'format',
-      description: "The format to display the output: 'table', 'json'",
-      default: 'table',
+      name: 'output',
+      aliases: ['o'],
+      description: "The format to display the output: 'pretty', 'json'",
+      default: 'pretty',
     },
   ],
 };

--- a/cli/fusebit-ops-cli/src/commands/stack/ListStackCommand.ts
+++ b/cli/fusebit-ops-cli/src/commands/stack/ListStackCommand.ts
@@ -15,12 +15,6 @@ const command = {
       name: 'deployment',
       description: 'The name of the deployment to filter by',
     },
-    {
-      name: 'format',
-      aliases: ['f'],
-      description: "The format to display the output: 'table', 'json'",
-      default: 'table',
-    },
   ],
 };
 
@@ -41,13 +35,13 @@ export class ListStackCommand extends Command {
     await input.io.writeLine();
 
     const deploymentName = input.options.deployment as string;
-    const format = input.options.format as string;
+    const output = input.options.output as string;
 
     const stackService = await StackService.create(input);
     const deploymentService = await DeploymentService.create(input);
     const deployments = await deploymentService.listAllDeployments();
 
-    if (format === 'json') {
+    if (output === 'json') {
       const stacks = await stackService.listAllStacks(deploymentName);
       await stackService.displayStacks(stacks, deployments);
     } else {

--- a/cli/fusebit-ops-cli/src/commands/stack/StackCommand.ts
+++ b/cli/fusebit-ops-cli/src/commands/stack/StackCommand.ts
@@ -14,6 +14,14 @@ const command: ICommand = {
   cmd: 'stack',
   summary: 'Manage stacks',
   description: 'Deploy, promote, demote, destroy and list stacks of deployments',
+  options: [
+    {
+      name: 'output',
+      aliases: ['o'],
+      description: "The format to display the output: 'pretty', 'json'",
+      default: 'pretty',
+    },
+  ],
 };
 
 // ----------------

--- a/cli/fusebit-ops-cli/src/commands/subscription/ListSubscriptionCommand.ts
+++ b/cli/fusebit-ops-cli/src/commands/subscription/ListSubscriptionCommand.ts
@@ -18,10 +18,10 @@ const command = {
   ],
   options: [
     {
-      name: 'format',
-      aliases: ['f'],
-      description: "The format to display the output: 'table', 'json'",
-      default: 'table',
+      name: 'output',
+      aliases: ['o'],
+      description: "The format to display the output: 'pretty', 'json'",
+      default: 'pretty',
     },
     {
       name: 'region',

--- a/cli/fusebit-ops-cli/src/services/AccountService.ts
+++ b/cli/fusebit-ops-cli/src/services/AccountService.ts
@@ -120,7 +120,7 @@ export class AccountService {
   }
 
   public async displayAccounts(accounts: IOpsAccount[]) {
-    if (this.input.options.format === 'json') {
+    if (this.input.options.output === 'json') {
       this.input.io.writeLine(JSON.stringify(accounts, null, 2));
       return;
     }

--- a/cli/fusebit-ops-cli/src/services/DeploymentService.ts
+++ b/cli/fusebit-ops-cli/src/services/DeploymentService.ts
@@ -336,7 +336,7 @@ export class DeploymentService {
   }
 
   public async displaySubscriptions(deployment: IOpsDeployment, accounts: IFusebitAccount[]) {
-    if (this.input.options.format === 'json') {
+    if (this.input.options.output === 'json') {
       this.input.io.writeLine(JSON.stringify(accounts, null, 2));
       return;
     }
@@ -356,7 +356,7 @@ export class DeploymentService {
   }
 
   public async displayInit(init: IInitAdmin) {
-    if (this.input.options.format === 'json') {
+    if (this.input.options.output === 'json') {
       this.input.io.writeLine(JSON.stringify(init, null, 2));
       return;
     }
@@ -405,7 +405,7 @@ export class DeploymentService {
   }
 
   public async displayDeployments(deployments: IOpsDeployment[]) {
-    if (this.input.options.format === 'json') {
+    if (this.input.options.output === 'json') {
       this.input.io.writeLine(JSON.stringify(deployments, null, 2));
       return;
     }
@@ -422,7 +422,7 @@ export class DeploymentService {
   }
 
   public async displayDeployment(deployment: IOpsDeployment) {
-    if (this.input.options.format === 'json') {
+    if (this.input.options.output === 'json') {
       this.input.io.writeLine(JSON.stringify(deployment, null, 2));
       return;
     }
@@ -462,7 +462,7 @@ export class DeploymentService {
   }
 
   public async displaySubscription(subscription: IFusebitSubscription) {
-    if (this.input.options.format === 'json') {
+    if (this.input.options.output === 'json') {
       this.input.io.writeLine(JSON.stringify(subscription, null, 2));
       return;
     }

--- a/cli/fusebit-ops-cli/src/services/DomainService.ts
+++ b/cli/fusebit-ops-cli/src/services/DomainService.ts
@@ -137,7 +137,7 @@ export class DomainService {
   }
 
   public async displayDomains(domains: IOpsDomain[]) {
-    if (this.input.options.format === 'json') {
+    if (this.input.options.output === 'json') {
       this.input.io.writeLine(JSON.stringify(domains, null, 2));
       return;
     }
@@ -154,7 +154,7 @@ export class DomainService {
   }
 
   public async displayDomain(domain: IOpsDomain) {
-    if (this.input.options.format === 'json') {
+    if (this.input.options.output === 'json') {
       this.input.io.writeLine(JSON.stringify(domain, null, 2));
       return;
     }

--- a/cli/fusebit-ops-cli/src/services/ExecuteService.ts
+++ b/cli/fusebit-ops-cli/src/services/ExecuteService.ts
@@ -31,7 +31,7 @@ export class ExecuteService {
   public async execute<T>(messages: IExcuteMessages, func?: () => Promise<T | undefined>) {
     try {
       if (messages.header || messages.message) {
-        if (!this.input.options.quiet) {
+        if (!this.input.options.quiet && this.isPrettyOutput()) {
           const message = await Message.create({
             header: messages.header,
             message: messages.message || '',
@@ -69,7 +69,7 @@ export class ExecuteService {
   }
 
   public async message(header: IText, message: IText, kind: MessageKind = MessageKind.result) {
-    if (!this.input.options.quiet) {
+    if (!this.input.options.quiet && this.isPrettyOutput()) {
       const formattedMessage = await Message.create({ header, message, kind });
       await formattedMessage.write(this.input.io);
     }

--- a/cli/fusebit-ops-cli/src/services/ImageService.ts
+++ b/cli/fusebit-ops-cli/src/services/ImageService.ts
@@ -111,7 +111,7 @@ export class ImageService {
   }
 
   public async displayImages(images: IOpsImage[]) {
-    if (this.input.options.format === 'json') {
+    if (this.input.options.output === 'json') {
       this.input.io.writeLine(JSON.stringify(images, null, 2));
       return;
     }

--- a/cli/fusebit-ops-cli/src/services/NetworkService.ts
+++ b/cli/fusebit-ops-cli/src/services/NetworkService.ts
@@ -204,7 +204,7 @@ export class NetworkService {
   }
 
   public async displayNetworks(networks: IOpsNetwork[]) {
-    if (this.input.options.format === 'json') {
+    if (this.input.options.output === 'json') {
       this.input.io.writeLine(JSON.stringify(networks, null, 2));
       return;
     }
@@ -221,7 +221,7 @@ export class NetworkService {
   }
 
   public async displayNetwork(network: IOpsNetwork) {
-    if (this.input.options.format === 'json') {
+    if (this.input.options.output === 'json') {
       this.input.io.writeLine(JSON.stringify(network, null, 2));
       return;
     }

--- a/cli/fusebit-ops-cli/src/services/PortalService.ts
+++ b/cli/fusebit-ops-cli/src/services/PortalService.ts
@@ -893,7 +893,7 @@ export class PortalService {
   }
 
   public async displayPortals(portals: FusebitDistribution[]): Promise<void> {
-    if (this.input.options.format === 'json') {
+    if (this.input.options.output === 'json') {
       this.input.io.writeLine(JSON.stringify(portals, null, 2));
       return;
     }
@@ -934,7 +934,7 @@ export class PortalService {
   }
 
   public async displayPortal(portal: IPortal) {
-    if (this.input.options.format === 'json') {
+    if (this.input.options.output === 'json') {
       this.input.io.writeLine(JSON.stringify(portal, null, 2));
       return;
     }

--- a/cli/fusebit-ops-cli/src/services/ProfileService.ts
+++ b/cli/fusebit-ops-cli/src/services/ProfileService.ts
@@ -355,7 +355,7 @@ export class ProfileService {
   }
 
   public async displayProfiles(profiles: IFusebitOpsProfile[]) {
-    if (this.input.options.format === 'json') {
+    if (this.input.options.output === 'json') {
       await this.input.io.writeLine(JSON.stringify(profiles, null, 2));
       return;
     }
@@ -369,7 +369,7 @@ export class ProfileService {
   }
 
   public async displayProfile(profile: IFusebitOpsProfile) {
-    if (this.input.options.format === 'json') {
+    if (this.input.options.output === 'json') {
       await this.input.io.writeLine(JSON.stringify(profile, null, 2));
       return;
     }

--- a/cli/fusebit-ops-cli/src/services/StackService.ts
+++ b/cli/fusebit-ops-cli/src/services/StackService.ts
@@ -213,6 +213,10 @@ export class StackService {
       'Stack Removed',
       `Stack '${Text.bold(id.toString())}' of deployment '${Text.bold(deploymentName)}' was successfully removed`
     );
+
+    if (this.input.options.output === 'json') {
+      this.input.io.writeLine(JSON.stringify({ id, deploymentName, region, active: false }, null, 2));
+    }
   }
 
   public async getStack(deploymentName: string, region: string, id: number): Promise<IOpsStack> {
@@ -268,7 +272,7 @@ export class StackService {
   }
 
   public async displayStacks(stacks: IOpsStack[], deployments: IOpsDeployment[]) {
-    if (this.input.options.format === 'json') {
+    if (this.input.options.output === 'json') {
       this.input.io.writeLine(JSON.stringify(stacks, null, 2));
       return;
     }
@@ -292,7 +296,7 @@ export class StackService {
   }
 
   public async displayStack(stack: IOpsStack) {
-    if (this.input.options.format === 'json') {
+    if (this.input.options.output === 'json') {
       this.input.io.writeLine(JSON.stringify(stack, null, 2));
       return;
     }

--- a/docs/release-notes/fusebit-ops-cli.md
+++ b/docs/release-notes/fusebit-ops-cli.md
@@ -23,6 +23,7 @@ All public releases of the Fusebit Operations CLI are documented here, including
 _Released 12/18/20_
 
 - **Bugfix.** Enforce consistent reads to DynamoDB for table access operations.
+- **Bugfix.** Normalize output format control to `--output,-o`, removing the `--format,-f` option.
 
 ## Version 1.24.14
 

--- a/lib/data/ops-data-aws/src/tables/StackTable.ts
+++ b/lib/data/ops-data-aws/src/tables/StackTable.ts
@@ -64,8 +64,8 @@ function onStackAlreadyExists(stack: IOpsStack) {
 }
 
 function onStackDoesNotExist(deploymentName: string) {
-  return (stackId: number) => {
-    throw OpsDataException.noStack(stackId, deploymentName);
+  return (stackId: { id: number }) => {
+    throw OpsDataException.noStack(stackId.id, deploymentName);
   };
 }
 

--- a/tool/cicd/actions/deploy_exclusive_function_api.sh
+++ b/tool/cicd/actions/deploy_exclusive_function_api.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# -- Standard Header --
+set -e
+echoerr() { printf "%s\n" "$*" >&2; }
+FUSEOPS="node cli/fusebit-ops-cli/libc/index.js"
+export FUSEBIT_DEBUG=
+
+# -- Parameter Validation --
+if [ -z "${DEPLOYMENT_NAME}" ]; then
+  echoerr "ERROR: DEPLOYMENT_NAME is unset."
+  exit -1
+fi
+
+if [ -z "${REGION}" ]; then
+  echoerr "ERROR: REGION is unset."
+  exit -1
+fi
+
+# -- Optional Parameters --
+IMG_VER=${VERSION_FUNCTION_API:=`jq -r '.version' ./package.json`}
+ENV_FILE=${ENV_FILE:=./gc_bq.env}
+
+# -- Script --
+
+ALL_STACKS=`${FUSEOPS} stack ls -o json --deployment ${DEPLOYMENT_NAME}`
+OLD_STACKS=`echo ${ALL_STACKS} | jq --arg region ${REGION} -r 'map(select(.region == $region)) | .[] | .id'`
+
+echoerr "Deploying stack ${DEPLOYMENT_NAME}/${REGION}: ${IMG_VER}"
+STACK_ADD_PARAMS="--region ${REGION} -c false -o json --env ${ENV_FILE}"
+STACK_ADD=`${FUSEOPS} stack add ${DEPLOYMENT_NAME} ${IMG_VER} ${STACK_ADD_PARAMS}`
+NEW_STACK_ID=`echo ${STACK_ADD} | jq -r '.id'`
+
+echoerr "Promoting stack ${DEPLOYMENT_NAME}: ${NEW_STACK_ID}"
+${FUSEOPS} stack promote ${DEPLOYMENT_NAME} ${NEW_STACK_ID} --region ${REGION} -c f 1>&2
+
+echoerr "Deleting old stacks: ${OLD_STACKS}"
+echo -n ${OLD_STACKS} | \
+  xargs -d ' ' -I STACKID \
+  ${FUSEOPS} stack rm ${DEPLOYMENT_NAME} STACKID --force true -c f --region ${REGION} -o json 1>&2
+
+echoerr "Completed successfully:"
+echo { \"deployment\": \"${DEPLOYMENT_NAME}\", \"id\": \"${NEW_STACK_ID}\" }

--- a/tool/cicd/actions/publish_function_api.sh
+++ b/tool/cicd/actions/publish_function_api.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# -- Standard Header --
+set -e
+echoerr() { printf "%s\n" "$*" >&2; }
+FUSEOPS="node cli/fusebit-ops-cli/libc/index.js"
+export FUSEBIT_DEBUG=
+
+# -- Optional Parameters --
+IMG_VER=${VERSION_FUNCTION_API:=`jq -r '.version' ./package.json`}
+
+# -- Script --
+${FUSEOPS} image publish ${IMG_VER} 1>&2
+
+echoerr "Completed successfully:"
+echo { \"version\": \"${IMG_VER}\" }

--- a/tool/cicd/actions/publish_fusebit_cli.sh
+++ b/tool/cicd/actions/publish_fusebit_cli.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# -- Standard Header --
+set -e
+echoerr() { printf "%s\n" "$*" >&2; }
+FUSEOPS="node cli/fusebit-ops-cli/libc/index.js"
+export FUSEBIT_DEBUG=
+
+# -- Optional Parameters --
+AWS_PROFILE=${AWS_PROFILE:=default}
+VERSION=${VERSION_FUSEBIT_CLI:=`jq -r '.version' ./cli/fusebit-cli/package.json`}
+
+# -- Script --
+echoerr "Building package"
+rm -rf cli/fusebit-cli/package
+yarn package fusebit-cli 1>&2
+
+echoerr "Deploying to npm"
+cd cli/fusebit-cli/package
+npm publish 1>&2
+
+echoerr "Testing installation"
+npm install -g @fusebit/cli@${VERSION} 1>&2
+
+echoerr "Completed successfully:"
+echo { \"version\": \"${VERSION}\" }

--- a/tool/cicd/actions/publish_fusebit_ops_cli.sh
+++ b/tool/cicd/actions/publish_fusebit_ops_cli.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# -- Standard Header --
+set -e
+echoerr() { printf "%s\n" "$*" >&2; }
+FUSEOPS="node cli/fusebit-ops-cli/libc/index.js"
+export FUSEBIT_DEBUG=
+
+# -- Optional Parameters --
+AWS_PROFILE=${AWS_PROFILE:=default}
+VERSION=${VERSION_FUSEBIT_OPS_CLI:=`jq -r '.version' ./cli/fusebit-ops-cli/package.json`}
+
+# -- Script --
+MAJOR_MINOR=`echo ${VERSION} | sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)/\1.\2/'`
+echoerr "Creating fusebit-ops-cli package: ${VERSION} at ${MAJOR_MINOR}"
+rm -rf cli/fusebit-ops-cli/package
+yarn package fusebit-ops-cli 1>&2
+
+echoerr "Creating fusebit-ops-cli npm tgz"
+cd cli/fusebit-ops-cli/package
+npm pack 1>&2
+
+echoerr "Publishing to fusebit-ops-cli to S3"
+aws --profile=${AWS_PROFILE} s3 cp \
+  --acl public-read --content-type application/gzip --cache-control max-age=300 \
+  fusebit-ops-cli-${VERSION}.tgz	\
+  s3://fusebit-io-cdn/fusebit/cli/fusebit-ops-cli-v${MAJOR_MINOR}.tgz 1>&2
+
+echoerr "Validating package is accessible and installable"
+npm -g i https://cdn.fusebit.io/fusebit/cli/fusebit-ops-cli-v${MAJOR_MINOR}.tgz 1>&2
+
+echoerr "Completed successfully:"
+echo { \"version\": \"${VERSION}\" }

--- a/tool/cicd/profile/createProfileBundle.js
+++ b/tool/cicd/profile/createProfileBundle.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env -S node --no-warnings
+
+const fs = require("fs");
+const path = require("path");
+const homedir = require("os").homedir();
+
+const userProfileRoot = `${homedir}/.fusebit`;
+const userProfileName = "github-action-stage-us-west-2";
+const opsProfileRoot = `${homedir}/.fusebit-ops`;
+const opsProfileName = "github-automation";
+
+const renderUserProfile = () => {
+  const settings = JSON.parse(
+    fs.readFileSync(path.join(userProfileRoot, "settings.json"))
+  );
+  const kid = settings.profiles[userProfileName].kid;
+  const privateKey = fs
+    .readFileSync(
+      path.join(userProfileRoot, "keys", userProfileName, kid, "pri")
+    )
+    .toString();
+  const publicKey = fs
+    .readFileSync(
+      path.join(userProfileRoot, "keys", userProfileName, kid, "pub")
+    )
+    .toString();
+
+  const output = {
+    settings: {
+      profiles: { [userProfileName]: settings.profiles[userProfileName] },
+      defaults: { profile: userProfileName },
+    },
+    keys: { privateKey, publicKey },
+    keyPath: path.join("keys", userProfileName, kid),
+    profileName: userProfileName,
+  };
+  return output;
+};
+
+const renderOpsProfile = () => {
+  const settings = JSON.parse(
+    fs.readFileSync(path.join(opsProfileRoot, "settings.json"))
+  );
+  const output = {
+    settings: {
+      profiles: { [opsProfileName]: settings.profiles[opsProfileName] },
+      defaults: { profile: opsProfileName },
+    },
+    profileName: opsProfileName,
+  };
+  return output;
+};
+
+const result = { user: renderUserProfile(), ops: renderOpsProfile() };
+console.log(JSON.stringify(result));


### PR DESCRIPTION
Change fusebit-ops-cli to match fusebit-cli, which exclusively uses --output,-o as the way to control output formatting (json, pretty, etc).

Additionally, add tooling for GIthubActions.