### PR TITLE
ignore node_modules directory when reading file tree

### DIFF
--- a/cli/fusebit-cli/src/services/FunctionService.ts
+++ b/cli/fusebit-cli/src/services/FunctionService.ts
@@ -32,7 +32,7 @@ function getTemplateDirectoryPath(): string {
 }
 
 async function getTemplateFiles(): Promise<string[]> {
-  return readDirectory(getTemplateDirectoryPath(), { joinPaths: false, filesOnly: true, ignoreDependencies: true });
+  return readDirectory(getTemplateDirectoryPath(), { joinPaths: false, filesOnly: true, ignore: ['node_modules'] });
 }
 
 async function getTemplateOverWriteFiles(path: string): Promise<string[]> {
@@ -60,7 +60,7 @@ async function getSaveOverWriteFiles(path: string, functionSpec: any): Promise<s
     recursive: false,
     filesOnly: true,
     joinPaths: false,
-    ignoreDependencies: true,
+    ignore: ['node_modules'],
   });
 
   const overwriteFiles = [];
@@ -250,7 +250,7 @@ export class FunctionService {
       filesOnly: true,
       joinPaths: false,
       recursive: true,
-      ignoreDependencies: true,
+      ignore: ['node_modules'],
     });
     for (const file of files) {
       if (file !== '.gitignore' && file !== 'fusebit.json') {

--- a/lib/node/file/src/copyDirectory.ts
+++ b/lib/node/file/src/copyDirectory.ts
@@ -13,7 +13,6 @@ async function recursiveCopy(sourcePath: string, destinationPath: string, option
     errorIfNotExist: options.errorIfNotExist,
     recursive: false,
     ignore: options.ignore,
-    ignoreDependencies: options.ignoreDependencies,
   });
 
   for (const item of items) {
@@ -26,6 +25,7 @@ async function recursiveCopy(sourcePath: string, destinationPath: string, option
           errorIfNotExist: options.errorIfNotExist,
           filesOnly: options.filesOnly,
           recursive: true,
+          ignore: options.ignore,
         };
         await recursiveCopy(itemSourcePath, itemDestinationPath, recursiveOptions);
       }
@@ -57,7 +57,6 @@ export async function copyDirectory(
     errorIfNotExist?: boolean;
     errorIfExists?: boolean;
     ignore?: string[];
-    ignoreDependencies?: boolean;
   } = {}
 ): Promise<void> {
   options.ensurePath = options.ensurePath === false ? false : true;

--- a/lib/node/file/src/readDirectory.ts
+++ b/lib/node/file/src/readDirectory.ts
@@ -31,7 +31,6 @@ export async function readDirectory(
     filesOnly?: boolean;
     errorIfNotExist?: boolean;
     ignore?: string[];
-    ignoreDependencies?: boolean;
   } = {}
 ): Promise<string[]> {
   options.recursive = options.recursive === false ? false : true;
@@ -44,20 +43,14 @@ export async function readDirectory(
       throw error;
     }
   }
-  const ignore = options.ignore || [];
-  if (options.ignoreDependencies) {
-    ignore.push('node_modules');
+
+  if (options.ignore) {
+    items = items.filter((item) => !options.ignore?.includes(item));
   }
-  items = items.filter((item) => !ignore.includes(item));
 
   if (options.recursive || options.filesOnly) {
     const filteredItems = [];
-    const recursiveOptions = {
-      filesOnly: options.filesOnly,
-      recursive: true,
-      ignore: options.ignore,
-      ignoreDependencies: options.ignoreDependencies,
-    };
+    const recursiveOptions = { filesOnly: options.filesOnly, recursive: true, ignore: options.ignore };
 
     for (const item of items) {
       const itemPath = join(path, item);


### PR DESCRIPTION
We don't want to push up the `node_modules` directory on a function publish (or really, whenever doing anything.  It's a managed directory)