### PR TITLE
Wrong slice frame

### DIFF
--- a/cli/fusebit-cli/src/commands/npm/NpmExecCommand.ts
+++ b/cli/fusebit-cli/src/commands/npm/NpmExecCommand.ts
@@ -47,7 +47,7 @@ export class NpmExecCommand extends Command {
 
   public async execute(args: string[], io: ICommandIO): Promise<number> {
     // Chop off the leading 'npm exec'
-    args = args.slice(3);
+    args = args.slice(2);
 
     const profile = await this.getProfile(args, io);
     const registries = await getRegistry(profile);


### PR DESCRIPTION
Just a typo.  Currently, the `exec` function drops the first argument provided, so you have to do funky stuff like `fuse npm exec this_is_a_meaningless_string init`