### PR TITLE
[fuse-cli 1.9.6] Fix parsing of local dates in fuse CLI

### DIFF
--- a/cli/fusebit-cli/package.json
+++ b/cli/fusebit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/fusebit-cli",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "",
   "main": "libc/index.js",
   "bin": {

--- a/cli/fusebit-cli/src/commands/InitCommand.ts
+++ b/cli/fusebit-cli/src/commands/InitCommand.ts
@@ -239,10 +239,19 @@ export class InitCommand extends Command {
           token,
           initResolve as IFusebitInitResolve
         );
+        if (input.options.verbose) {
+          console.log('RESOLVED AGENT', agent);
+        }
 
         const agentDetails = await agentService.getAgentDetails(agent, true);
+        if (input.options.verbose) {
+          console.log('AGENT DETAILS', agentDetails);
+        }
         await profileService.displayProfile(addedProfile, agentDetails);
       } catch (e) {
+        if (input.options.verbose) {
+          console.log('INIT ERROR', e);
+        }
         await profileService.removeProfile(profileName);
         throw e;
       }

--- a/cli/fusebit-cli/src/services/ExecuteService.ts
+++ b/cli/fusebit-cli/src/services/ExecuteService.ts
@@ -73,6 +73,13 @@ export class ExecuteService {
 
     const func = async (): Promise<any> => {
       const response = await sendRequest(request);
+      if (this.input.options.verbose) {
+        console.log('EXECUTE SERVICE REQUEST', request, '\nEXECUTE SERVICE RESPONSE', {
+          status: response.status,
+          headers: response.headers,
+          data: response.data,
+        });
+      }
       if (response.status === 201 && retryOn201) {
         await new Promise((resolve) => setTimeout(resolve, 2000));
         return await func();

--- a/cli/fusebit-cli/src/services/ProfileService.ts
+++ b/cli/fusebit-cli/src/services/ProfileService.ts
@@ -23,22 +23,6 @@ const QR = require('qrcode-terminal');
 const profileOptions = ['account', 'subscription', 'boundary', 'function'];
 const notSet = Text.dim(Text.italic('<not set>'));
 
-// ------------------
-// Internal Functions
-// ------------------
-
-function getDateString(date: Date) {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-
-  const dateOnly = new Date(date.valueOf());
-  dateOnly.setHours(0, 0, 0, 0);
-
-  const dateOnlyMs = dateOnly.valueOf();
-  const [dateString, timeString] = date.toLocaleString().split(',');
-  return dateOnlyMs === today.valueOf() ? timeString.trim() : dateString.trim();
-}
-
 // -------------------
 // Exported Interfaces
 // -------------------
@@ -803,13 +787,7 @@ export class ProfileService {
     }
 
     details.push(
-      ...[
-        Text.dim('Created: '),
-        getDateString(new Date(profile.created)),
-        Text.dim(' • '),
-        Text.dim('Last Updated: '),
-        getDateString(new Date(profile.updated)),
-      ]
+      ...[Text.dim('Created: '), profile.created, Text.dim(' • '), Text.dim('Last Updated: '), profile.updated]
     );
 
     if (agentDetails) {

--- a/docs/release-notes/fusebit-cli.md
+++ b/docs/release-notes/fusebit-cli.md
@@ -17,6 +17,13 @@ All public releases of the Fusebit CLI are documented here, including notable ch
 <!-- 1. TOC
 {:toc} -->
 
+## Version 1.9.6
+
+_Released 6/4/21_
+
+- **Enhancement.** Added more verbose output for diagnostics.
+- **Bugfix** Fixed formatting of dates to be locale-agnostic.
+
 ## Version 1.9.4
 
 _Released 5/25/21_

--- a/docs/release-notes/release-notes.md
+++ b/docs/release-notes/release-notes.md
@@ -35,7 +35,7 @@ Fusebit Ops CLI <code>v1.26+</code> - <a href="{{ site.baseurl }}{% link release
 <td style="width:30%">
 <dl>
   <dt>Last updated</dt>
-  <dd>5/13/2021</dd>
+  <dd>6/4/2021</dd>
   <dt>LTS release</dt>
   <dd>No</dd>
 </dl>

--- a/lib/node/cli/src/Command.ts
+++ b/lib/node/cli/src/Command.ts
@@ -596,6 +596,7 @@ export class Command implements ICommand {
         options[option.name] = parsed;
       }
     }
+    options.verbose = options.verbose || !!process.env.FUSEBIT_DEBUG;
 
     const input: IExecuteInput = {
       terms: command.terms,


### PR DESCRIPTION
Dates in Denmark are formatted in a way that makes fuse CLI fail. This makes `fuse init` treat dates in a locale-agnostic way. 