### PR TITLE
ENG-167 - VSCode Settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,9 +3,6 @@
   "editor.formatOnSave": true,
   "editor.tabSize": 2,
   "files.exclude": {
-    ".gitignore": true,
-    ".vscode/**": true,
-    ".yarnrc": true,
     "**/*.tsbuildinfo": true,
     "**/devServer.js": true,
     "**/imports.d.ts": true,
@@ -14,5 +11,6 @@
     "**/prettier.config.js": true,
     "**/tslint.json": true
   },
-  "typescript.disableAutomaticTypeAcquisition": true
+  "typescript.disableAutomaticTypeAcquisition": true,
+  "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
Hiding files like `.gitignore` and the `.vscode` directory isn't much of a help IMO, quite the contrary actually. Also, it is a good practice to use the local TypeScript version instead of whatever VSCode decides for you.