### PR TITLE
ENG-180 Removing old @types/node versions

### DIFF
--- a/lib/client/fusebit-editor/package.json
+++ b/lib/client/fusebit-editor/package.json
@@ -30,7 +30,6 @@
     "@fortawesome/free-regular-svg-icons": "^5.6.0",
     "@fortawesome/free-solid-svg-icons": "^5.6.0",
     "@types/jquery": "^3.3.22",
-    "@types/node": "^10.12.9",
     "@types/superagent": "^4.1.7",
     "css-loader": "^1.0.1",
     "jsdom": "11.11.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/html-webpack-plugin": "^3.2.0",
     "@types/html-webpack-template": "^6.0.3",
     "@types/jest": "^24.0.25",
-    "@types/node": "^14.17.2",
+    "@types/node": "14.17.2",
     "clean-webpack-plugin": "^1.0.1",
     "css-loader": "^2.1.0",
     "file-loader": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2697,20 +2697,15 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.14.tgz#1c1d6e3c75dba466e0326948d56e8bd72a1903d2"
   integrity sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==
 
-"@types/node@^10.12.9":
-  version "10.17.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.6.tgz#1aaabd6f6470a6ac3824ab1e94d731ca1326d93d"
-  integrity sha512-0a2X6cgN3RdPBL2MIlR6Lt0KlM7fOFsutuXcdglcOq6WvLnYXgPQSh0Mx6tO1KCAE8MxbHSOSTWDoUxRq+l3DA==
+"@types/node@14.17.2":
+  version "14.17.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.2.tgz#1e94476db57ec93a372c7f7d29aa5707cfb92339"
+  integrity sha512-sld7b/xmFum66AAKuz/rp/CUO8+98fMpyQ3SBfzzBNGMd/1iHBTAg9oyAvcYlAj46bpc74r91jSw2iFdnx29nw==
 
 "@types/node@^13.11.1":
   version "13.13.33"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.33.tgz#300e65e0b465bda102b9845d172d8d45726a2dd8"
   integrity sha512-1B3GM1yuYsFyEvBb+ljBqWBOylsWDYioZ5wpu8AhXdIhq20neXS7eaSC8GkwHE0yQYGiOIV43lMsgRYTgKZefQ==
-
-"@types/node@^14.17.2":
-  version "14.17.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.4.tgz#218712242446fc868d0e007af29a4408c7765bc0"
-  integrity sha512-8kQ3+wKGRNN0ghtEn7EGps/B8CzuBz1nXZEIGGLP2GnwbqYn4dbTs7k+VKLTq1HvZLRCIDtN3Snx1Ege8B7L5A==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
This PR removes the explicit dependency from `@5qtrs/fusebit-editor` and pins the "global" dependency to `14.17.2`.