### PR TITLE
Fix Test Compilation Errors

### DIFF
--- a/api/function-api/package.json
+++ b/api/function-api/package.json
@@ -9,7 +9,7 @@
     "build": "tsc -b",
     "create-env": "node createEnv.js",
     "dev": "yarn build && node --inspect=9229 --trace-warnings libc/index.js",
-    "test": "yarn create-env && jest --colors",
+    "test": "yarn create-env && jest --colors --no-cache",
     "coverage": "jest --colors --coverage --detectOpenHandles",
     "lint": "tslint --fix -t stylish src/{,**/}*.ts{,x} test/{,**/}*.ts{,x}",
     "clean": "rm -r -f libc",

--- a/api/function-api/src/routes/service/OperationService.ts
+++ b/api/function-api/src/routes/service/OperationService.ts
@@ -83,9 +83,12 @@ class OperationService {
           operationEntity.data.code = 200;
         }
       } catch (err) {
-        console.log(err);
-        // Update operation with the error message
-        operationEntity.data = { ...operation, code: err.status || err.statusCode || 500, message: err.message };
+        if (err.message && err.message.match(/duplicate key value/)) {
+          operationEntity.data = { ...operation, code: 400, message: `Duplicate key value: ${entity.id}` };
+        } else {
+          // Update operation with the error message
+          operationEntity.data = { ...operation, code: err.status || err.statusCode || 500, message: err.message };
+        }
       }
 
       console.log(

--- a/api/function-api/test/v1/execution.test.ts
+++ b/api/function-api/test/v1/execution.test.ts
@@ -23,7 +23,7 @@ describe('Execution', () => {
         },
       },
     });
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await request(response.data.location);
     expect(response).toBeHttp({ statusCode: 200 });
     expect(response.data).toEqual('hello');
@@ -49,7 +49,7 @@ describe('Execution', () => {
     expect(response).toBeHttp({ statusCode: [200, 201] });
     if (response.status === 201) {
       response = await waitForBuild(account, response.data, 15, 1000);
-      expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+      expect(response).toBeHttp({ statusCode: 200 });
     }
     response = await request(response.data.location);
     expect(response).toBeHttp({ statusCode: 200 });
@@ -85,7 +85,7 @@ describe('Execution', () => {
     };
 
     let response = await putFunction(account, boundaryId, function1Id, reflectContext);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await request({
       method: 'POST',
       url: response.data.location,
@@ -116,7 +116,7 @@ describe('Execution', () => {
         },
       },
     });
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await request(response.data.location);
     expect(response.status).toEqual(418);
     expect(response.data).toEqual('teapot');
@@ -131,7 +131,7 @@ describe('Execution', () => {
         },
       },
     });
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await request(response.data.location);
     expect(response).toBeHttp({ statusCode: 200 });
     expect(response.data).toEqual('teapot');
@@ -148,7 +148,7 @@ describe('Execution', () => {
         },
       },
     });
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await request(response.data.location);
     expect(response).toBeHttp({ statusCode: 200 });
     expect(response.data).toEqual(undefined);
@@ -163,7 +163,7 @@ describe('Execution', () => {
         },
       },
     });
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await request(response.data.location);
     expect(response).toBeHttp({ statusCode: 200 });
     expect(response.data).toEqual(undefined);
@@ -209,7 +209,7 @@ describe('Execution', () => {
         },
       },
     });
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await request(response.data.location);
     expect(response.status).toEqual(500);
     expect(response.headers['x-fx-response-source']).toEqual('provider');
@@ -233,7 +233,7 @@ describe('Execution', () => {
         },
       },
     });
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await request(response.data.location);
     expect(response.status).toEqual(500);
     expect(response.headers['x-fx-response-source']).toEqual('provider');
@@ -257,7 +257,7 @@ describe('Execution', () => {
         },
       },
     });
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await request(response.data.location);
     expect(response.status).toEqual(500);
     expect(response.headers['x-fx-response-source']).toEqual('provider');
@@ -281,7 +281,7 @@ describe('Execution', () => {
         },
       },
     });
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await request(response.data.location);
     expect(response.status).toEqual(500);
     expect(response.headers['x-fx-response-source']).toEqual('provider');
@@ -313,7 +313,7 @@ describe('Execution', () => {
         },
       },
     });
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await request(response.data.location);
     expect(response.status).toEqual(500);
     expect(response.headers['x-fx-response-source']).toEqual('provider');
@@ -342,7 +342,7 @@ describe('Execution', () => {
         },
       },
     });
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await request({
       method: 'POST',
       url: response.data.location,
@@ -372,7 +372,7 @@ describe('Execution', () => {
         },
       },
     });
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await request({
       method: 'POST',
       url: response.data.location,
@@ -391,7 +391,7 @@ describe('Execution', () => {
         },
       },
     });
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await request(response.data.location);
     expect(response.status).toEqual(500);
     expect(response.headers['x-fx-response-source']).toEqual('provider');
@@ -423,7 +423,7 @@ describe('Execution', () => {
         },
       },
     });
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await request(response.data.location);
     expect(response).toBeHttp({ statusCode: 200 });
     expect(response.data).toEqual('hello');
@@ -439,7 +439,7 @@ describe('Execution', () => {
         },
       },
     });
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await request(response.data.location);
     expect(response).toBeHttp({ statusCode: 200 });
     expect(response.data).toEqual(account.accountId);
@@ -454,7 +454,7 @@ test('Function with x-www-form-urlencoded works', async () => {
       },
     },
   });
-  expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+  expect(response).toBeHttp({ statusCode: 200 });
   const params = new URLSearchParams();
   params.append('test', '123');
 
@@ -482,7 +482,7 @@ test('function with payload above limit fails (x-www-form-encoded)', async () =>
       },
     },
   });
-  expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+  expect(response).toBeHttp({ statusCode: 200 });
   const params = new URLSearchParams();
   params.append('test', '.'.repeat(520 * 1024));
   const executionResponse = await request({

--- a/api/function-api/test/v1/function.legacy.test.ts
+++ b/api/function-api/test/v1/function.legacy.test.ts
@@ -155,7 +155,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with applicationSettings sets configuration', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithApplicationSettings);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await getFunction(account, boundaryId, function1Id);
     expect(response).toBeHttp({ statusCode: 200 });
     expect(response.data.configuration).toEqual({ FOO: '123', BAR: 'abc' });
@@ -169,7 +169,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with computeSettings sets compute', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithComputeSettings);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await getFunction(account, boundaryId, function1Id);
     expect(response).toBeHttp({ statusCode: 200 });
     expect(response.data.configuration).toBeUndefined();
@@ -183,7 +183,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with cronSettings sets schedule', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithCronSettings);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await getFunction(account, boundaryId, function1Id);
     expect(response).toBeHttp({ statusCode: 200 });
     expect(response.data.configuration).toBeUndefined();
@@ -199,7 +199,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with applicationSettings set to empty string resets applicationSettings', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithApplicationSettings);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -210,7 +210,7 @@ describe.skip('Function Legacy', () => {
     response.data.metadata.fusebit.applicationSettings = '';
 
     response = await putFunction(account, boundaryId, function1Id, response.data);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -221,7 +221,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with computeSettings set to empty string resets computeSettings', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithComputeSettings);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -231,7 +231,7 @@ describe.skip('Function Legacy', () => {
 
     response.data.metadata.fusebit.computeSettings = '';
     response = await putFunction(account, boundaryId, function1Id, response.data);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -242,7 +242,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with cronSettings set to empty string resets schedule', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithCronSettings);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -252,7 +252,7 @@ describe.skip('Function Legacy', () => {
     response.data.metadata.fusebit.cronSettings = '';
 
     response = await putFunction(account, boundaryId, function1Id, response.data);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
     expect(response.data.schedule).toEqual({ cron: '0 0 1 1 *', timezone: 'UTC' });
@@ -261,7 +261,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with applicationSettings undefined is ignored', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithConfigurationAndMetadata);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -280,7 +280,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with computeSettings undefined is ignored', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithStaticIp);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -298,7 +298,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with cronSettings undefined is ignored', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithCron);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -317,7 +317,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with empty compute resets compute', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithComputeSettings);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -327,7 +327,7 @@ describe.skip('Function Legacy', () => {
 
     response.data.compute = {};
     response = await putFunction(account, boundaryId, function1Id, response.data);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -338,7 +338,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with empty configuration resets configuration', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithConfigurationAndMetadata);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -348,7 +348,7 @@ describe.skip('Function Legacy', () => {
 
     response.data.configuration = {};
     response = await putFunction(account, boundaryId, function1Id, response.data);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -359,7 +359,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with empty schedule resets schedule', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithCron);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -378,7 +378,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with undefined compute is ignored', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithStaticIp);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -398,7 +398,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with undefined configuration is ignored', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithConfigurationAndMetadata);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -419,7 +419,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with undefined schedule is ignored', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithCron);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -439,7 +439,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with undefined compute and undefined computeSettings resets compute', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithComputeSettings);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -450,7 +450,7 @@ describe.skip('Function Legacy', () => {
     response.data.metadata.fusebit.computeSettings = undefined;
     response.data.compute = undefined;
     response = await putFunction(account, boundaryId, function1Id, response.data);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -460,7 +460,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with undefined configuration and undefined applicationSettings resets configuration', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithConfigurationAndMetadata);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -471,7 +471,7 @@ describe.skip('Function Legacy', () => {
     response.data.metadata.fusebit.applicationSettings = undefined;
     response.data.configuration = undefined;
     response = await putFunction(account, boundaryId, function1Id, response.data);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -482,7 +482,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with undefined schedule and undefined cronSettings resets schedule', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithCron);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -493,7 +493,7 @@ describe.skip('Function Legacy', () => {
     response.data.metadata.fusebit.cronSettings = undefined;
     response.data.schedule = undefined;
     response = await putFunction(account, boundaryId, function1Id, response.data);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -525,7 +525,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with new configuration values configuration compute and applicationSettings', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithConfigurationAndMetadata);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -545,7 +545,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with new schedule values updates schedule and cronSettings', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithCron);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -586,7 +586,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with non-conflicting metadata and structured data changes is supported', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithConfigurationAndMetadata);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await getFunction(account, boundaryId, function1Id);
     const data = response.data;
     data.compute.timeout = 60;
@@ -611,7 +611,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with conflicting configuration and application settings uses configuration', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithConfigurationAndMetadata);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await getFunction(account, boundaryId, function1Id);
 
     const data = response.data;
@@ -628,7 +628,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with conflicting schedule and cronSettings uses schedule', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithCron);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -649,7 +649,7 @@ describe.skip('Function Legacy', () => {
 
   test('PUT with conflicting compute and computeSettings uses compute', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorld);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await getFunction(account, boundaryId, function1Id);
 
     const data = response.data;
@@ -686,7 +686,7 @@ describe.skip('Function Legacy', () => {
 
   test('GET retrieves information of simple function', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorld);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await getFunction(account, boundaryId, function1Id);
     expect(response).toBeHttp({ statusCode: 200 });
     expect(response.data).toMatchObject({
@@ -707,7 +707,7 @@ describe.skip('Function Legacy', () => {
 
   test('GET retrieves information of function with package.json as JavaScript object', async () => {
     let response = await putFunction(account, boundaryId, function2Id, helloWorldWithNode8JavaScript);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await getFunction(account, boundaryId, function2Id);
     expect(response).toBeHttp({ statusCode: 200 });
     expect(response.data).toMatchObject({
@@ -728,7 +728,7 @@ describe.skip('Function Legacy', () => {
 
   test('GET retrieves information of function with package.json as string', async () => {
     let response = await putFunction(account, boundaryId, function2Id, helloWorldWithNode8String);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await getFunction(account, boundaryId, function2Id);
     expect(response).toBeHttp({ statusCode: 200 });
     expect(response.data).toMatchObject({

--- a/api/function-api/test/v1/function.serialized.test.ts
+++ b/api/function-api/test/v1/function.serialized.test.ts
@@ -96,7 +96,7 @@ describe('Function Serialized', () => {
 
   test('PUT with configurationSerialized sets configuration', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithConfigurationSerialized);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await getFunction(account, boundaryId, function1Id, true);
     expect(response).toBeHttp({ statusCode: 200 });
     expect(response.data.configuration).toEqual({ FOO: '123', BAR: 'abc' });
@@ -105,7 +105,7 @@ describe('Function Serialized', () => {
 
   test('PUT with configurationSerialized with empty value sets configuration', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithConfigurationSerializedEmptyValue);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await getFunction(account, boundaryId, function1Id, true);
     expect(response).toBeHttp({ statusCode: 200 });
     expect(response.data.configuration).toEqual({ FOO: '', BAR: 'abc' });
@@ -122,7 +122,7 @@ describe('Function Serialized', () => {
 
   test('PUT with computeSerialized sets compute', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithComputeSerialized);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await getFunction(account, boundaryId, function1Id, true);
     expect(response).toBeHttp({ statusCode: 200 });
     expect(response.data.configuration).toBeUndefined();
@@ -133,7 +133,7 @@ describe('Function Serialized', () => {
 
   test('PUT with scheduleSerialized sets schedule', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithScheduleSerialized);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await getFunction(account, boundaryId, function1Id, true);
     expect(response).toBeHttp({ statusCode: 200 });
     expect(response.data.configuration).toBeUndefined();
@@ -144,7 +144,7 @@ describe('Function Serialized', () => {
 
   test('PUT with configurationSerialized set to empty string resets configurationSerialized', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithConfigurationSerialized);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -155,7 +155,7 @@ describe('Function Serialized', () => {
     response.data.configurationSerialized = '';
 
     response = await putFunction(account, boundaryId, function1Id, response.data);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -166,7 +166,7 @@ describe('Function Serialized', () => {
 
   test('PUT with computeSerialized set to empty string resets computeSerialized', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithComputeSerialized);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -176,7 +176,7 @@ describe('Function Serialized', () => {
 
     response.data.computeSerialized = '';
     response = await putFunction(account, boundaryId, function1Id, response.data);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -187,7 +187,7 @@ describe('Function Serialized', () => {
 
   test('PUT with scheduleSerialized set to empty string resets scheduleSerialized', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithScheduleSerialized);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -197,7 +197,7 @@ describe('Function Serialized', () => {
     response.data.scheduleSerialized = '';
 
     response = await putFunction(account, boundaryId, function1Id, response.data);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
     expect(response.data.schedule).toEqual({ cron: '0 0 1 1 *', timezone: 'UTC' });
@@ -206,7 +206,7 @@ describe('Function Serialized', () => {
 
   test('PUT with configurationSerialized undefined is ignored', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithConfigurationSerialized);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -220,7 +220,7 @@ describe('Function Serialized', () => {
 
   test('PUT with computeSerialized undefined is ignored', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithComputeSerialized);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -234,7 +234,7 @@ describe('Function Serialized', () => {
 
   test('PUT with scheduleSerialized undefined is ignored', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithScheduleSerialized);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id);
 
@@ -248,7 +248,7 @@ describe('Function Serialized', () => {
 
   test('PUT with empty compute resets compute', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithComputeSerialized);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -258,7 +258,7 @@ describe('Function Serialized', () => {
 
     response.data.compute = {};
     response = await putFunction(account, boundaryId, function1Id, response.data);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -269,7 +269,7 @@ describe('Function Serialized', () => {
 
   test('PUT with empty configuration resets configuration', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithConfiguration);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -279,7 +279,7 @@ describe('Function Serialized', () => {
 
     response.data.configuration = {};
     response = await putFunction(account, boundaryId, function1Id, response.data);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -290,7 +290,7 @@ describe('Function Serialized', () => {
 
   test('PUT with empty schedule resets schedule', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithCron);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -309,7 +309,7 @@ describe('Function Serialized', () => {
 
   test('PUT with undefined configuration is ignored', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithConfiguration);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -324,7 +324,7 @@ describe('Function Serialized', () => {
 
   test('PUT with undefined schedule is ignored', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithCron);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -339,7 +339,7 @@ describe('Function Serialized', () => {
 
   test('PUT with undefined compute and undefined computeSerialized resets compute', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithComputeSerialized);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -350,7 +350,7 @@ describe('Function Serialized', () => {
     response.data.computeSerialized = undefined;
     response.data.compute = undefined;
     response = await putFunction(account, boundaryId, function1Id, response.data);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -361,7 +361,7 @@ describe('Function Serialized', () => {
 
   test('PUT with undefined configuration and undefined configurationSerialized resets configuration', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithConfiguration);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -372,7 +372,7 @@ describe('Function Serialized', () => {
     response.data.configurationSerialized = undefined;
     response.data.configuration = undefined;
     response = await putFunction(account, boundaryId, function1Id, response.data);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -383,7 +383,7 @@ describe('Function Serialized', () => {
 
   test('PUT with undefined schedule and undefined scheduleSerialized resets schedule', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithCron);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -394,7 +394,7 @@ describe('Function Serialized', () => {
     response.data.scheduleSerialized = undefined;
     response.data.schedule = undefined;
     response = await putFunction(account, boundaryId, function1Id, response.data);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -405,7 +405,7 @@ describe('Function Serialized', () => {
 
   test('PUT with new configuration values updates configuration and configurationSerialized', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithConfiguration);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -425,7 +425,7 @@ describe('Function Serialized', () => {
 
   test('PUT with new schedule values updates schedule and scheduleSerialized', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithCron);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -445,7 +445,7 @@ describe('Function Serialized', () => {
 
   test('PUT with non-conflicting serialized and structured data changes is supported', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithConfiguration);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await getFunction(account, boundaryId, function1Id, true);
     const data = response.data;
     data.compute.timeout = 60;
@@ -464,7 +464,7 @@ describe('Function Serialized', () => {
 
   test('PUT with conflicting configuration and configurationSerialized uses configuration', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithConfiguration);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await getFunction(account, boundaryId, function1Id, true);
 
     const data = response.data;
@@ -481,7 +481,7 @@ describe('Function Serialized', () => {
 
   test('PUT with conflicting schedule and scheduleSerialized uses schedule', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithCron);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 
@@ -502,7 +502,7 @@ describe('Function Serialized', () => {
 
   test('PUT with conflicting compute and computeSerialized uses compute', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorld);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await getFunction(account, boundaryId, function1Id, true);
 
     const data = response.data;
@@ -520,7 +520,7 @@ describe('Function Serialized', () => {
 
   test('GET retrieves information of simple function', async () => {
     let response = await putFunction(account, boundaryId, function1Id, helloWorld);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await getFunction(account, boundaryId, function1Id, true);
     expect(response).toBeHttp({ statusCode: 200 });
     expect(response.data).toMatchObject({

--- a/api/function-api/test/v1/function.staticip.test.ts
+++ b/api/function-api/test/v1/function.staticip.test.ts
@@ -5,10 +5,11 @@ import { IAgent, ISubscription } from '@5qtrs/account-data';
 import * as Constants from '@5qtrs/constants';
 
 import * as FunctionUtilities from '../../src/routes/functions';
-import { getParams, fakeAgent, createRegistry, keyStore, subscriptionCache } from './function.utils';
+import { getParams, fakeAgent, subscriptionCache } from './function.utils';
 import {
   putFunction,
   refreshSubscriptionCache,
+  getSubscription,
   waitForBuild,
   getFunction,
   disableFunctionUsageRestriction,
@@ -20,8 +21,6 @@ let { account, boundaryId, function1Id, function2Id, function3Id, function4Id, f
 beforeEach(() => {
   ({ account, boundaryId, function1Id, function2Id, function3Id, function4Id, function5Id } = getEnv());
 });
-
-FunctionUtilities.initFunctions(keyStore, subscriptionCache);
 
 const dynamo = new DynamoDB({ apiVersion: '2012-08-10' });
 const lambda = new Lambda({ apiVersion: '2015-03-31' });
@@ -81,6 +80,7 @@ async function setSubscriptionStaticIpFlag(subscription: ISubscription, staticIp
       ':flags': { S: JSON.stringify(flags) },
     },
   };
+
   await dynamo.updateItem(params).promise();
   subscriptionCache.refresh();
 
@@ -208,7 +208,7 @@ describe('Subscription with staticIp=true', () => {
 
     let response = await putFunction(account, boundaryId, function1Id, helloWorldWithStaticIp);
     response = await waitForBuild(account, response.data, 120, 1000);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
 
     response = await getFunction(account, boundaryId, function1Id, true);
 

--- a/api/function-api/test/v1/function.utility.test.ts
+++ b/api/function-api/test/v1/function.utility.test.ts
@@ -1,13 +1,12 @@
 import create_error from 'http-errors';
 
 import { IAgent } from '@5qtrs/account-data';
-import { AwsRegistry } from '@5qtrs/registry';
 import * as FunctionUtilities from '../../src/routes/functions';
 
 import { disableFunctionUsageRestriction, callFunction } from './sdk';
 
 import { getEnv } from './setup';
-import { getParams, keyStore, subscriptionCache, fakeAgent } from './function.utils';
+import { getParams, fakeAgent } from './function.utils';
 
 let { account, boundaryId, function1Id, function2Id, function3Id, function4Id, function5Id } = getEnv();
 beforeEach(() => {
@@ -25,12 +24,6 @@ const ctxFunction = {
     files: { 'index.js': 'module.exports = (ctx, cb) => cb(null, { body: { ...ctx, configuration: undefined } });' },
   },
 };
-
-// Register the globals with various consumers
-FunctionUtilities.initFunctions(keyStore, subscriptionCache);
-
-// Create a registry object
-const registry = AwsRegistry.create({ ...getParams('', account, boundaryId), registryId: 'default' }, {});
 
 describe('Function Utilities', () => {
   test('Create simple function', async () => {

--- a/api/function-api/test/v1/function.utils.ts
+++ b/api/function-api/test/v1/function.utils.ts
@@ -1,8 +1,8 @@
 import { IAccount } from './accountResolver';
 import { AwsRegistry } from '@5qtrs/registry';
-import { AwsKeyStore } from '@5qtrs/runas';
-import { SubscriptionCache } from '@5qtrs/account';
 import { terminate_garbage_collection } from '@5qtrs/function-lambda';
+
+import { keyStore, subscriptionCache } from '../../src/routes/globals';
 
 export const createRegistry = (account: IAccount, boundaryId: string) => {
   return AwsRegistry.create({ ...getParams('', account, boundaryId), registryId: 'default' }, {});
@@ -19,12 +19,6 @@ export const fakeAgent = {
   checkPermissionSubset: async () => Promise.resolve(),
 };
 
-export const keyStore = new AwsKeyStore({});
-
-// Create and load a cache with the current subscription->account mapping
-export const subscriptionCache = new SubscriptionCache({});
-subscriptionCache.refresh();
-
 beforeAll(async () => {
   return keyStore.rekey();
 });
@@ -32,3 +26,5 @@ afterAll(() => {
   keyStore.shutdown();
   terminate_garbage_collection();
 });
+
+export { keyStore, subscriptionCache };

--- a/api/function-api/test/v1/module.test.ts
+++ b/api/function-api/test/v1/module.test.ts
@@ -53,11 +53,11 @@ describe('Module', () => {
     if (response.status === 201) {
       response = await waitForBuild(account, response.data, 15, 1000);
     }
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
     response = await deleteFunction(account, boundaryId, function1Id);
     expect(response).toBeHttp({ statusCode: 204 });
     response = await putFunction(account, boundaryId, function1Id, helloWorldWithSuperagentDependency);
-    expect(response).toBeHttp({ statusCode: 200, status: 'success' });
+    expect(response).toBeHttp({ statusCode: 200 });
   }, 180000);
 
   test('PUT completes for function with complex dependencies', async () => {

--- a/api/function-api/test/v2/crud.test.ts
+++ b/api/function-api/test/v2/crud.test.ts
@@ -154,7 +154,8 @@ const performTests = (testEntityType: TestableEntityTypes, sampleEntityMap: Samp
     const entity = sampleEntity();
     await createEntityTest(entity);
     const createResponseConflict = await ApiRequestMap[testEntityType].post(account, entity);
-    expect(createResponseConflict).toBeHttp({ status: 400 });
+    const operation = await ApiRequestMap.operation.waitForCompletion(account, createResponseConflict.data.operationId);
+    expect(operation).toBeHttp({ statusCode: 400 });
   }, 180000);
 
   test('Update Entity', async () => {

--- a/lib/data/db/src/daos/entity.ts
+++ b/lib/data/db/src/daos/entity.ts
@@ -29,7 +29,7 @@ import {
 const DELETE_SAFETY_PREFIX_LEN = 3;
 
 const defaultEntityConstructorArgument: DefaultConstructorArguments = {
-  upsert: true,
+  upsert: false,
   filterExpired: true,
   listLimit: 100,
 };

--- a/lib/server/account/src/SubscriptionCache.ts
+++ b/lib/server/account/src/SubscriptionCache.ts
@@ -146,16 +146,12 @@ export default class SubscriptionCache {
 
     await this.refreshDefaults();
 
-    console.log(`CACHE: Subscription cache refreshed: ${results.length} subscriptions loaded`);
-
     return this.allowRefreshAfter;
   }
 
   public async refreshDefaults() {
     try {
       this.defaults = await Defaults.get(this.dynamo, Constants.DEFAULTS_SUBSCRIPTION);
-
-      console.log(`CACHE: Subscription defaults refreshed: ${JSON.stringify(this.defaults)}`);
     } catch (e) {
       console.log(`CACHE: Subscription defaults not loaded: ${e}`);
     }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.20.29",
+  "version": "1.20.30",
   "private": true,
   "org": "5qtrs",
   "engines": {

--- a/tool/cicd/actions/scripts/build_tree.sh
+++ b/tool/cicd/actions/scripts/build_tree.sh
@@ -16,3 +16,7 @@ yarn --frozen-lockfile install
 
 echoerr "yarn build:"
 yarn build
+
+echoerr "Validate tests all build:"
+cd api/function-api
+EC2=1 LAMBDA_USER_FUNCTION_PERMISSIONLESS_ROLE=1 yarn test --no-cache --forceExit --testNamePattern=DoesNotMatchAnyTests


### PR DESCRIPTION
Additionally, this uncovered a bug where duplicate createEntity calls were not generating errors.

Finally, automated builds have been modified to validate that the tests fully compile.