### PR TITLE
ENG-111 Dashboard Template

### DIFF
--- a/tool/monitoring/README.md
+++ b/tool/monitoring/README.md
@@ -3,14 +3,14 @@
 Use the following command to export the CloudWatch Dashboard definition:
 
 ```bash
-./cloudwatch-dashboard.sh us-east-1
+./cloudwatch-dashboard.sh relia us-east-1
 ```
 
-This will generate a JSON output with the dashboard definition for the `us-east-1` region. You can use this JSON definition to create the dashboard at the AWS Console. Or, if you prefer, you can use the following commands to update a dashboard directly from your terminal:
+This will generate a JSON output with the dashboard definition for the `relia` deployment on the `us-east-1` region. You can use this JSON definition to create the dashboard at the AWS Console. Or, if you prefer, you can use the following commands to update a dashboard directly from your terminal:
 
 ```bash
 DASHBOARD_NAME=ENG-140-US-EAST-1
-DASHBOARD_BODY=$(./cloudwatch-dashboard.sh us-east-1 | jq -c)
+DASHBOARD_BODY=$(./cloudwatch-dashboard.sh relia us-east-1 | jq -c)
 
 aws cloudwatch put-dashboard --dashboard-name $DASHBOARD_NAME --dashboard-body $DASHBOARD_BODY
 ```
@@ -18,5 +18,5 @@ aws cloudwatch put-dashboard --dashboard-name $DASHBOARD_NAME --dashboard-body $
 Also, if you are on Mac and prefer a more manual process, you can also use the following command to copy the JSON output directly to the transfer area and then paste it on AWS Console:
 
 ```bash
-./cloudwatch-dashboard.sh us-east-1 | pbcopy
+./cloudwatch-dashboard.sh relia us-east-1 | pbcopy
 ```

--- a/tool/monitoring/cloudwatch-dashboard-template.json
+++ b/tool/monitoring/cloudwatch-dashboard-template.json
@@ -10,7 +10,7 @@
         "metrics": [
           [
             {
-              "expression": "SEARCH('{AWS/ApplicationELB,LoadBalancer} MetricName=\"RequestCount\" ', 'Sum', 60)"
+              "expression": "SEARCH('{AWS/ApplicationELB,LoadBalancer} MetricName=\"RequestCount\" AND DEPLOYMENT_NAME', 'Sum', 60)"
             }
           ]
         ],
@@ -30,7 +30,7 @@
         "metrics": [
           [
             {
-              "expression": "SEARCH('{AWS/ApplicationELB,LoadBalancer} MetricName=\"HTTPCode_Target_2XX_Count\" ', 'Sum', 60)"
+              "expression": "SEARCH('{AWS/ApplicationELB,LoadBalancer} MetricName=\"HTTPCode_Target_2XX_Count\" AND DEPLOYMENT_NAME', 'Sum', 60)"
             }
           ]
         ],
@@ -50,7 +50,7 @@
         "metrics": [
           [
             {
-              "expression": "SEARCH('{AWS/ApplicationELB,LoadBalancer} MetricName=\"HTTPCode_ELB_4XX_Count\" ', 'Sum', 60)"
+              "expression": "SEARCH('{AWS/ApplicationELB,LoadBalancer} MetricName=\"HTTPCode_ELB_4XX_Count\" AND DEPLOYMENT_NAME', 'Sum', 60)"
             }
           ]
         ],
@@ -70,7 +70,7 @@
         "metrics": [
           [
             {
-              "expression": "SEARCH('{AWS/ApplicationELB,LoadBalancer} MetricName=\"HTTPCode_ELB_5XX_Count\" ', 'Sum', 60)"
+              "expression": "SEARCH('{AWS/ApplicationELB,LoadBalancer} MetricName=\"HTTPCode_ELB_5XX_Count\" AND DEPLOYMENT_NAME', 'Sum', 60)"
             }
           ]
         ],
@@ -90,7 +90,7 @@
         "metrics": [
           [
             {
-              "expression": "SEARCH('{AWS/EC2,AutoScalingGroupName} MetricName=\"CPUUtilization\" ', 'Average', 300)"
+              "expression": "SEARCH('{AWS/EC2,AutoScalingGroupName} MetricName=\"CPUUtilization\" AND DEPLOYMENT_NAME', 'Average', 300)"
             }
           ]
         ],
@@ -112,7 +112,7 @@
         "metrics": [
           [
             {
-              "expression": "SEARCH('{CWAgent,AutoScalingGroupName,ImageId,InstanceId,InstanceType} mem_used_percent', 'Average', 300)"
+              "expression": "SEARCH('{CWAgent,AutoScalingGroupName,ImageId,InstanceId,InstanceType} mem_used_percent AND DEPLOYMENT_NAME', 'Average', 300)"
             }
           ]
         ],
@@ -130,12 +130,12 @@
         "metrics": [
           [
             {
-              "expression": "SEARCH('{AWS/ApplicationELB,TargetGroup,LoadBalancer} MetricName=\"UnHealthyHostCount\" ', 'Sum', 60)"
+              "expression": "SEARCH('{AWS/ApplicationELB,TargetGroup,LoadBalancer} MetricName=\"UnHealthyHostCount\" AND DEPLOYMENT_NAME', 'Sum', 60)"
             }
           ],
           [
             {
-              "expression": "SEARCH('{AWS/ApplicationELB,TargetGroup,LoadBalancer} MetricName=\"HealthyHostCount\" ', 'Sum', 60)"
+              "expression": "SEARCH('{AWS/ApplicationELB,TargetGroup,LoadBalancer} MetricName=\"HealthyHostCount\" AND DEPLOYMENT_NAME', 'Sum', 60)"
             }
           ]
         ],
@@ -155,7 +155,7 @@
         "metrics": [
           [
             {
-              "expression": "SEARCH('{AWS/ApplicationELB,LoadBalancer} MetricName=\"TargetResponseTime\" ', 'Average', 60)"
+              "expression": "SEARCH('{AWS/ApplicationELB,LoadBalancer} MetricName=\"TargetResponseTime\" AND DEPLOYMENT_NAME', 'Average', 60)"
             }
           ]
         ],

--- a/tool/monitoring/cloudwatch-dashboard.sh
+++ b/tool/monitoring/cloudwatch-dashboard.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-AWS_REGION=$1
+DEPLOYMENT_NAME=$1
+AWS_REGION=$2
 
-MYDIR="$(dirname "$(which "$0")")"
+SCRIPT_DIR="$(dirname "$(which "$0")")"
 
-cat $MYDIR/cloudwatch-dashboard-template.json | sed 's/AWS_REGION/'$AWS_REGION'/g'
+cat $SCRIPT_DIR/cloudwatch-dashboard-template.json | sed 's/AWS_REGION/'$AWS_REGION'/g' | sed 's/DEPLOYMENT_NAME/'$DEPLOYMENT_NAME'/g'


### PR DESCRIPTION
This PR introduces the `tool/monitoring/cloudwatch-dashboard.sh` script to export a CloudWatch Dashboard JSON template to be used for deployment monitoring. More info on the `tool/monitoring/README.md` file.