### PR TITLE
Update the integration and connector fuse cli output

### DIFF
--- a/cli/fusebit-cli/package.json
+++ b/cli/fusebit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/fusebit-cli",
-  "version": "1.9.17",
+  "version": "1.9.18",
   "description": "",
   "main": "libc/index.js",
   "bin": {

--- a/cli/fusebit-cli/src/services/ConnectorService.ts
+++ b/cli/fusebit-cli/src/services/ConnectorService.ts
@@ -12,10 +12,8 @@ interface IConnector extends IBaseComponentType {
 }
 
 export class ConnectorService extends BaseComponentService<IConnector> {
-  protected entityType: EntityType;
-
   private constructor(profileService: ProfileService, executeService: ExecuteService, input: IExecuteInput) {
-    super(profileService, executeService, input);
+    super(EntityType.connector, profileService, executeService, input);
     this.entityType = EntityType.connector;
   }
 
@@ -49,12 +47,11 @@ export class ConnectorService extends BaseComponentService<IConnector> {
         });
       }
 
-      // const itemList = Text.join(functions, Text.eol());
       await this.executeService.message(
         Text.bold(item.id),
         Text.create([
-          `Package: `,
-          Text.bold(item.data.configuration.package || ''),
+          `Handler: `,
+          Text.bold(item.data.handler || ''),
           Text.eol(),
           Text.eol(),
           ...tagSummary,

--- a/cli/fusebit-cli/src/services/IntegrationService.ts
+++ b/cli/fusebit-cli/src/services/IntegrationService.ts
@@ -11,11 +11,8 @@ interface IIntegration extends IBaseComponentType {
 }
 
 export class IntegrationService extends BaseComponentService<IIntegration> {
-  protected entityType: EntityType;
-
   private constructor(profileService: ProfileService, executeService: ExecuteService, input: IExecuteInput) {
-    super(profileService, executeService, input);
-    this.entityType = EntityType.integration;
+    super(EntityType.integration, profileService, executeService, input);
   }
 
   public static async create(input: IExecuteInput) {


### PR DESCRIPTION
Change the `fuse` command output for `log` and `edit` to refer to `integration` and `connector` appropriately, instead of `function` leaking through.