### PR TITLE
Add tenant endpoints for integration SDK

### DIFF
--- a/lib/pkg/framework/src/Tenant.ts
+++ b/lib/pkg/framework/src/Tenant.ts
@@ -1,0 +1,54 @@
+import superagent from 'superagent';
+
+export interface ITenantRequestParams {
+  baseUrl: string;
+  accountId: string;
+  subscriptionId: string;
+  instanceId: string;
+  accessToken: string;
+  integrationId: string;
+}
+
+export interface ITenant {
+  [key: string]: string;
+}
+
+export interface IInstance {
+  id: string;
+  tags: ITenant;
+  data?: any;
+  expires?: string;
+  version?: string;
+}
+
+export interface IHttpResponse {
+  status: number;
+  body: any;
+}
+
+export interface ITenantRequest {
+  get(tenantId: string): Promise<IInstance | undefined>;
+  delete(tenantId: string): Promise<IHttpResponse>;
+}
+
+export const createRequest = (params: ITenantRequestParams): ITenantRequest => {
+  const functionUrl = new URL(params.baseUrl);
+  const baseUrl = `${functionUrl.protocol}//${functionUrl.host}/v2/account/${params.accountId}/subscription/${params.subscriptionId}`;
+  const instanceUrl = `/integration/${params.integrationId}/instance?tag=tenant=`;
+  return {
+    async get(tenantId: string): Promise<IInstance | undefined> {
+      const response = await superagent
+        .get(`${baseUrl}${instanceUrl}${tenantId}`)
+        .set('Authorization', `Bearer ${params.accessToken}`)
+        .ok((res) => res.status < 300 || res.status === 404);
+      return response.status === 404 ? undefined : response.body?.data[0];
+    },
+    async delete(tenantId: string) {
+      const response = await superagent
+        .delete(`${baseUrl}${instanceUrl}${tenantId}`)
+        .set('Authorization', `Bearer ${params.accessToken}`)
+        .ok((res) => res.status < 300 || res.status === 404);
+      return response.status === 404 ? undefined : response.body.data;
+    },
+  };
+};

--- a/lib/pkg/framework/src/index.ts
+++ b/lib/pkg/framework/src/index.ts
@@ -6,6 +6,7 @@ import { Form } from './Form';
 import { Handler } from './Handler';
 import * as Middleware from './middleware';
 import IntegrationActivator from './IntegrationActivator';
+import * as Tenant from './Tenant';
 
 // Types
 export * from './Storage';
@@ -25,4 +26,5 @@ export {
   Middleware,
   Storage,
   IntegrationActivator,
+  Tenant,
 };

--- a/lib/pkg/integration/src/Integration.ts
+++ b/lib/pkg/integration/src/Integration.ts
@@ -1,4 +1,4 @@
-import { Router, Storage, Context, IListOption } from '@fusebit-int/framework';
+import { Router, Storage, Context, IListOption, Tenant } from '@fusebit-int/framework';
 
 class Integration {
   constructor() {
@@ -16,10 +16,8 @@ class Integration {
     deleteData: (ctx: Context, dataKey?: string) => Storage.createStorage(ctx.state.params).delete(dataKey),
     deleteDataWithPrefix: (ctx: Context, dataKeyPrefix?: string) =>
       Storage.createStorage(ctx.state.params).delete(dataKeyPrefix, true, true),
-    listTenants: async (ctx: Context, tags?: string | string[]) => undefined, //TODO
-    listInstanceTenants: async (instanceId: string) => undefined, //TODO
-    listTenantInstances: async (tenantId: string) => undefined, //TODO
-    deleteTenant: async (tenant: string) => undefined, //TODO
+    getTenant: (ctx: Context, tenantId: string) => Tenant.createRequest(ctx.state.params).get(tenantId),
+    deleteTenant: async (ctx: Context, tenantId: string) => Tenant.createRequest(ctx.state.params).delete(tenantId),
   };
 
   readonly middleware = {


### PR DESCRIPTION
This PR adds support for the following methods on the SDK:

**getTenant
deleteTenant**

The deleteTenant calls a new HTTP endpoint that removes an instance by providing a tag (filter by tenant name) - still need to discuss if this is the best approach with the team, but it works.

# How to test

You can perform the following requests, this endpoints are being called by the SDK in Tenant.ts

Delete tenant:

[DELETE] <fusebit-api>/v2/account/acc-{account-id}/subscription/sub-{subscription-id}/integration/{integration-id}/instance?tag={tag-name=tenant}=tag-value

Get tenant: 
[GET]  <fusebit-api>/v2/account/acc-{account-id}/subscription/sub-{subscription-id}/integration/{integration-id}/instance?tag={tag-name=tenant}=tag-value
