### PR TITLE
Support session error handling

### DIFF
--- a/api/function-api/src/routes/service/IntegrationService.ts
+++ b/api/function-api/src/routes/service/IntegrationService.ts
@@ -84,7 +84,7 @@ class IntegrationService extends SessionedEntityService<Model.IIntegration, Mode
       // Validate DAG of 'dependsOn' parameters.
       comp.dependsOn.forEach((dep: string) => {
         if (!dagList[dep]) {
-          throw http_error(400, `Ordering violation: 'uses' in '${comp.name}' for '${dep}' before declaration.`);
+          throw http_error(400, `Ordering violation: 'dependsOn' in '${comp.name}' for '${dep}' before declaration.`);
         }
       });
 

--- a/api/function-api/test/v2/sdk.ts
+++ b/api/function-api/test/v2/sdk.ts
@@ -651,13 +651,22 @@ export const createPair = async (
   expect(response.data.id).not.toMatch('/');
   const integ = response.data;
 
+  response = await ApiRequestMap.integration.dispatch(account, response.data.id, 'GET', '/api/health');
+  expect(response).toBeHttp({ statusCode: 200 });
+
   response = await ApiRequestMap.connector.postAndWait(account, { id: conId, data: connConfig });
   expect(response).toBeHttp({ statusCode: 200 });
   expect(response.data.id).not.toMatch('/');
   const conn = response.data;
 
+  response = await ApiRequestMap.connector.dispatch(account, response.data.id, 'GET', '/api/health');
+  expect(response).toBeHttp({ statusCode: 200 });
+
   for (let n = 1; n < numConnectors; n++) {
     response = await ApiRequestMap.connector.postAndWait(account, { id: `${conId}${n}`, data: connConfig });
+    expect(response).toBeHttp({ statusCode: 200 });
+
+    response = await ApiRequestMap.connector.dispatch(account, response.data.id, 'GET', '/api/health');
     expect(response).toBeHttp({ statusCode: 200 });
   }
 

--- a/api/function-api/test/v2/session.errors.test.ts
+++ b/api/function-api/test/v2/session.errors.test.ts
@@ -1,0 +1,107 @@
+import { request } from '@5qtrs/request';
+
+import { Model } from '@5qtrs/db';
+import { cleanupEntities, ApiRequestMap, createPair, getElementsFromUrl } from './sdk';
+
+import { getEnv } from '../v1/setup';
+
+let { account, boundaryId, function1Id, function2Id, function3Id, function4Id, function5Id } = getEnv();
+beforeEach(() => {
+  ({ account, boundaryId, function1Id, function2Id, function3Id, function4Id, function5Id } = getEnv());
+});
+
+afterAll(async () => {
+  await cleanupEntities(account);
+}, 180000);
+
+const demoRedirectUrl = 'http://monkey';
+
+describe('Sessions', () => {
+  test('POSTing an error on a connector session is reported during commit', async () => {
+    // Create multiple connectors to ensure the early-abort code is exercised
+    const { integrationId, connectorId } = await createPair(account, boundaryId, undefined, undefined, 3);
+    let response = await ApiRequestMap.integration.session.post(account, integrationId, {
+      redirectUrl: demoRedirectUrl,
+    });
+    expect(response).toBeHttp({ statusCode: 200 });
+
+    const parentSessionId = response.data.id;
+
+    response = await ApiRequestMap.integration.session.start(account, integrationId, parentSessionId);
+    expect(response).toBeHttp({ statusCode: 302 });
+    const location = new URL(response.headers.location);
+    const stepSessionId = location.searchParams.get('session');
+
+    // Test failure of this step
+    response = await ApiRequestMap.connector.session.put(account, connectorId, stepSessionId, {
+      error: 'bad_monkey',
+      errorDescription: 'worst',
+    });
+    expect(response).toBeHttp({ statusCode: 200 });
+
+    // Expect to be sent back to the parentSessionId, not to the next connector
+    response = await ApiRequestMap.connector.session.callback(account, connectorId, stepSessionId);
+    expect(response).toBeHttp({
+      statusCode: 302,
+      headers: { location: `${demoRedirectUrl}/?error=bad_monkey&errorDescription=worst&session=${parentSessionId}` },
+    });
+
+    // Post and check the session to see that the result is an error
+    response = await ApiRequestMap.integration.session.postSession(account, integrationId, parentSessionId);
+    expect(response).toBeHttp({ statusCode: 400 });
+    expect(response.data.message).toMatch(/bad_monkey/);
+  }, 180000);
+
+  test('POSTing an error on an integration session is reported during commit', async () => {
+    const { integrationId, connectorId, steps } = await createPair(
+      account,
+      boundaryId,
+      {
+        components: [
+          {
+            name: 'form',
+            entityType: Model.EntityType.integration,
+            entityId: `${boundaryId}-integ`,
+            path: '/api/authorize',
+            dependsOn: [],
+          },
+        ],
+      },
+      undefined,
+      3
+    );
+
+    let response = await ApiRequestMap.integration.session.post(account, integrationId, {
+      redirectUrl: demoRedirectUrl,
+    });
+    const parentSessionId = response.data.id;
+
+    // Start the session to make sure it starts correctly.
+    response = await ApiRequestMap.integration.session.start(account, integrationId, parentSessionId);
+    const location = new URL(response.headers.location);
+    const stepSessionId = location.searchParams.get('session');
+
+    // Validate that this is a form session
+    response = await ApiRequestMap.integration.session.get(account, integrationId, stepSessionId);
+    expect(response).toBeHttp({ statusCode: 200 });
+
+    // Test failure of this step
+    response = await ApiRequestMap.integration.session.put(account, integrationId, stepSessionId, {
+      error: 'bad_monkey',
+      errorDescription: 'worst',
+    });
+    expect(response).toBeHttp({ statusCode: 200 });
+
+    // Expect to be sent back to the parentSessionId, not to the next connector
+    response = await ApiRequestMap.integration.session.callback(account, integrationId, stepSessionId);
+    expect(response).toBeHttp({
+      statusCode: 302,
+      headers: { location: `${demoRedirectUrl}/?error=bad_monkey&errorDescription=worst&session=${parentSessionId}` },
+    });
+
+    // Post and check the session to see that the result is an error
+    response = await ApiRequestMap.integration.session.postSession(account, integrationId, parentSessionId);
+    expect(response).toBeHttp({ statusCode: 400 });
+    expect(response.data.message).toMatch(/bad_monkey/);
+  }, 180000);
+});

--- a/api/function-api/test/v2/session.test.ts
+++ b/api/function-api/test/v2/session.test.ts
@@ -50,14 +50,6 @@ describe('Sessions', () => {
     });
   }, 180000);
 
-  test('Creating a session on an existing connector returns 200', async () => {
-    const { integrationId } = await createPair(account, boundaryId);
-    const response = await ApiRequestMap.integration.session.post(account, integrationId, {
-      redirectUrl: demoRedirectUrl,
-    });
-    expect(response).toBeHttp({ statusCode: 200 });
-  }, 180000);
-
   test('Creating a session with no redirectUrl fails', async () => {
     const { integrationId } = await createPair(account, boundaryId);
     const response = await ApiRequestMap.integration.session.post(account, integrationId, {});
@@ -552,7 +544,7 @@ describe('Sessions', () => {
     });
     expect(response).toBeHttp({
       statusCode: 400,
-      data: { message: "Ordering violation: 'uses' in 'conn4' for 'conn3' before declaration." },
+      data: { message: "Ordering violation: 'dependsOn' in 'conn4' for 'conn3' before declaration." },
     });
   }, 180000);
 
@@ -565,7 +557,7 @@ describe('Sessions', () => {
     });
     expect(response).toBeHttp({
       statusCode: 400,
-      data: { message: "Ordering violation: 'uses' in 'conn2' for 'conn1' before declaration." },
+      data: { message: "Ordering violation: 'dependsOn' in 'conn2' for 'conn1' before declaration." },
     });
   }, 180000);
 

--- a/api/function-api/test/v2/workflow.test.ts
+++ b/api/function-api/test/v2/workflow.test.ts
@@ -337,7 +337,7 @@ describe('Workflow', () => {
     expect(response).toBeHttp({ statusCode: 200 });
     expect(response.data.access_token).toBe('original token');
 
-    // TODO: Modify the form page to query the connector with the contents of the session's 'uses' field, and
+    // TODO: Modify the form page to query the connector with the contents of the session's 'dependsOn' field, and
     //       related sessionId, and ensure that it gets back a valid token.
     //         Requires the connector to support looking up the contents by a sessionId instead of by a
     //         instanceId.

--- a/lib/pkg/oauth/oauth-connector/package.json
+++ b/lib/pkg/oauth/oauth-connector/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "libc/index.js",
   "files": ["libc/*.js", "libc/*.d.ts"],
+  "files": ["libc/**/*.js", "libc/**/*.d.ts", "libc/**/*.json"],
   "license": "SEE LICENSE IN LICENSE",
   "author": "Fusebit, Inc.",
   "scripts": {

--- a/lib/pkg/oauth/oauth-connector/src/IdentityClient.ts
+++ b/lib/pkg/oauth/oauth-connector/src/IdentityClient.ts
@@ -16,7 +16,7 @@ interface IOAuthToken {
 const removeLeadingSlash = (s: string) => s.replace(/^\/(.+)$/, '$1');
 const removeTrailingSlash = (s: string) => s.replace(/^(.+)\/$/, '$1');
 
-interface Params {
+interface IParams {
   subscriptionId: string;
   accountId: string;
   baseUrl: string;
@@ -32,7 +32,7 @@ class IdentityClient {
   private readonly accessToken: string;
   private readonly connectorId: string;
 
-  constructor(params: Params) {
+  constructor(params: IParams) {
     this.params = params;
     this.functionUrl = new URL(params.baseUrl);
     this.connectorId = params.entityId;
@@ -101,6 +101,15 @@ class IdentityClient {
       }
     });
     const response = await superagent.get(this.baseUrl).query(query).set('Authorization', `Bearer ${this.accessToken}`);
+    return response.body;
+  };
+
+  public saveErrorToSession = async (error: { error: string; errorDescription?: string }, sessionId: string) => {
+    sessionId = this.cleanId(sessionId);
+    const response = await superagent
+      .put(`${this.connectorUrl}/session/${sessionId}`)
+      .set('Authorization', `Bearer ${this.accessToken}`)
+      .send(error);
     return response.body;
   };
 

--- a/lib/pkg/oauth/oauth-connector/src/configure/index.ts
+++ b/lib/pkg/oauth/oauth-connector/src/configure/index.ts
@@ -1,0 +1,4 @@
+const uischema = require('./uischema.json');
+const schema = require('./schema.json');
+
+export { uischema, schema };

--- a/lib/pkg/oauth/oauth-connector/src/configure/schema.json
+++ b/lib/pkg/oauth/oauth-connector/src/configure/schema.json
@@ -1,0 +1,38 @@
+{
+  "type": "object",
+  "properties": {
+    "scope": {
+      "title": "Comma separated scopes to request from the OAuth server",
+      "type": "string"
+    },
+    "clientId": {
+      "title": "The client ID issued by the OAuth server",
+      "type": "string"
+    },
+    "tokenUrl": {
+      "type": "string"
+    },
+    "clientSecret": {
+      "type": "string"
+    },
+    "authorizationUrl": {
+      "type": "string"
+    },
+    "refreshErrorLimit": {
+      "type": "integer"
+    },
+    "refreshInitialBackoff": {
+      "type": "integer"
+    },
+    "refreshWaitCountLimit": {
+      "type": "integer"
+    },
+    "refreshBackoffIncrement": {
+      "type": "integer"
+    },
+    "accessTokenExpirationBuffer": {
+      "type": "integer"
+    }
+  },
+  "required": ["scope", "clientId", "clientSecret", "tokenUrl", "authorizationUrl"]
+}

--- a/lib/pkg/oauth/oauth-connector/src/configure/uischema.json
+++ b/lib/pkg/oauth/oauth-connector/src/configure/uischema.json
@@ -1,0 +1,45 @@
+{
+  "type": "VerticalLayout",
+  "elements": [
+    {
+      "type": "Control",
+      "scope": "#/properties/scope"
+    },
+    {
+      "type": "Control",
+      "scope": "#/properties/clientId"
+    },
+    {
+      "type": "Control",
+      "scope": "#/properties/tokenUrl"
+    },
+    {
+      "type": "Control",
+      "scope": "#/properties/clientSecret"
+    },
+    {
+      "type": "Control",
+      "scope": "#/properties/authorizationUrl"
+    },
+    {
+      "type": "Control",
+      "scope": "#/properties/refreshErrorLimit"
+    },
+    {
+      "type": "Control",
+      "scope": "#/properties/refreshInitialBackoff"
+    },
+    {
+      "type": "Control",
+      "scope": "#/properties/refreshWaitCountLimit"
+    },
+    {
+      "type": "Control",
+      "scope": "#/properties/refreshBackoffIncrement"
+    },
+    {
+      "type": "Control",
+      "scope": "#/properties/accessTokenExpirationBuffer"
+    }
+  ]
+}

--- a/lib/pkg/oauth/oauth-connector/tsconfig.json
+++ b/lib/pkg/oauth/oauth-connector/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": { "rootDir": "src", "module": "CommonJS", "outDir": "libc" },
-  "include": ["src"],
+  "include": ["src", "src/**/*.json"],
   "references": [{ "path": "../../framework" }]
 }

--- a/lib/pkg/slack/slack-connector/package.json
+++ b/lib/pkg/slack/slack-connector/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "",
   "main": "libc/index.js",
-  "files": ["libc/*.js", "libc/*.d.ts", "libc/configure/*.js", "libc/configure/*.json", "libc/configure/*.js"],
+  "files": ["libc/**/*.js", "libc/**/*.d.ts", "libc/**/*.json"],
   "license": "SEE LICENSE IN LICENSE",
   "author": "Fusebit, Inc.",
   "scripts": {

--- a/lib/pkg/slack/slack-connector/tsconfig.json
+++ b/lib/pkg/slack/slack-connector/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../../../tsconfig.json",
   "compilerOptions": { "rootDir": "src", "module": "CommonJS", "outDir": "libc" },
-  "include": ["src/*", "src/**/*.json", "src/configure/*"],
+  "include": ["src", "src/**/*.json"],
   "references": [{ "path": "../../framework" }, { "path": "../../oauth/oauth-connector" }]
 }


### PR DESCRIPTION
On an OAuth connection returning a call to /callback with an `error` query parameter, propagate the error back through the session, short-circuiting the session process and exposing the resulting error as part of the finalize operation.