### PR TITLE
Refactor session handling to streamline use

### DIFF
--- a/api/function-api/api_v2.yaml
+++ b/api/function-api/api_v2.yaml
@@ -138,6 +138,7 @@ paths:
         - $ref: '#/components/parameters/SearchCount'
         - $ref: '#/components/parameters/SearchNext'
         - $ref: '#/components/parameters/SearchTag'
+        - $ref: '#/components/parameters/SearchOperation'
       responses:
         200:
           description: A list of the objects found
@@ -166,7 +167,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OperationIdResponse'
+                $ref: '#/components/schemas/OperationIdUrlResponse'
       security:
         - AccessToken: []
 
@@ -212,7 +213,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OperationIdResponse'
+                $ref: '#/components/schemas/OperationIdUrlResponse'
       security:
         - AccessToken: []
     delete:
@@ -228,7 +229,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OperationIdResponse'
+                $ref: '#/components/schemas/OperationIdUrlResponse'
       security:
         - AccessToken: []
 
@@ -333,6 +334,7 @@ paths:
         - $ref: '#/components/parameters/SearchCount'
         - $ref: '#/components/parameters/SearchNext'
         - $ref: '#/components/parameters/SearchTag'
+        - $ref: '#/components/parameters/SearchOperation'
       responses:
         200:
           description: A list of the objects found
@@ -401,7 +403,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OperationIdResponse'
+                $ref: '#/components/schemas/OperationIdUrlResponse'
       security:
         - AccessToken: []
     delete:
@@ -417,7 +419,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OperationIdResponse'
+                $ref: '#/components/schemas/OperationIdUrlResponse'
       security:
         - AccessToken: []
 
@@ -441,6 +443,7 @@ paths:
         - $ref: '#/components/parameters/SearchCount'
         - $ref: '#/components/parameters/SearchNext'
         - $ref: '#/components/parameters/SearchTag'
+        - $ref: '#/components/parameters/SearchOperation'
       responses:
         200:
           description: A list of the objects found
@@ -557,6 +560,12 @@ components:
       description: A tag or tag=value to search for
       schema:
         type: string
+    SearchOperation:
+      name: operation
+      in: query
+      description: Get the associated entity that this operation is creating
+      schema:
+        $ref: '#/components/schemas/OperationId'
 
   requestBodies:
     PostConnectorBody:
@@ -641,7 +650,7 @@ components:
       required:
         - verb
         - type
-        - code
+        - statusCode
       properties:
         verb:
           type: string
@@ -651,7 +660,7 @@ components:
           type: string
           description: The type of the object being worked upon
           example: connector
-        code:
+        statusCode:
           type: number
           description:
             An HTTP status code indicating the current status of the
@@ -695,6 +704,27 @@ components:
       properties:
         operationId:
           $ref: '#/components/schemas/OperationId'
+
+    OperationIdUrlResponse:
+      type: object
+      required:
+        - operationId
+      description: A valid operation id for this operation.
+      properties:
+        operationId:
+          $ref: '#/components/schemas/OperationId'
+        target:
+          type: string
+          description:
+            Query this URL to track the status of the operation and, when
+            complete, receive the resulting object in the format of a list
+            operation.
+        statusOnly:
+          type: string
+          description:
+            This URL is a public URL suitable to be passed to an untrusted
+            client such as a web browser to drive an in-progress spinner. The
+            URL is always a GET request for `../operation/{operationId}`.
 
     ConnectorEntity:
       type: object

--- a/api/function-api/src/routes/schema/common/root.ts
+++ b/api/function-api/src/routes/schema/common/root.ts
@@ -10,7 +10,7 @@ import query from '../../handlers/query';
 import body from '../../handlers/body';
 import pathParams from '../../handlers/pathParams';
 
-import { SessionedEntityService } from '../../service';
+import { SessionedEntityService, operationService } from '../../service';
 
 const router = (EntityService: SessionedEntityService<any, any>) => {
   const componentRouter = express.Router({ mergeParams: true });
@@ -45,6 +45,25 @@ const router = (EntityService: SessionedEntityService<any, any>) => {
               total: 1,
             });
           }
+
+          if (req.query.operationId) {
+            const status = await operationService.getEntityByOperation(
+              req.params as { accountId: string; subscriptionId: string },
+              req.query.operationId as string,
+              EntityService.entityType
+            );
+
+            if (status.statusCode === 200 && (typeof status.result === 'object' || status.result === undefined)) {
+              // On object deletion, the return result will be undefined but the operation will be a success.
+              return res.json({
+                total: status.result ? 1 : 0,
+                items: [...(status.result ? [Model.entityToSdk(status.result)] : [])],
+              });
+            }
+
+            return res.status(status.statusCode).json({ message: status.result });
+          }
+
           const response = await EntityService.dao.listEntities(
             {
               ...pathParams.accountAndSubscription(req),

--- a/api/function-api/src/routes/schema/common/session.ts
+++ b/api/function-api/src/routes/schema/common/session.ts
@@ -39,45 +39,6 @@ const createSessionRouter = (SessionService: SessionedEntityService<any, any>) =
     }
   );
 
-  //  Get full value of session.
-  router.options('/:sessionId/result', common.cors());
-  router.route('/:sessionId/result').get(
-    common.management({
-      validate: { params: ValidationCommon.EntityIdParams },
-      authorize: { operation: v2Permissions.sessionResult },
-    }),
-    async (req: express.Request, res: express.Response, next: express.NextFunction) => {
-      try {
-        const session = await SessionService.getSession({
-          accountId: req.params.accountId,
-          subscriptionId: req.params.subscriptionId,
-          id: Model.createSubordinateId(SessionService.entityType, req.params.entityId, req.params.sessionId),
-        });
-        let result: any = {
-          id: req.params.sessionId,
-          input: session.result.data.input,
-          output: session.result.data.output,
-          components: session.result.data.components,
-          replacementTargetId: session.result.data.replacementTargetId,
-          operationId: session.result.data.operationId,
-        };
-
-        if (session.result.data.mode === 'leaf') {
-          result = {
-            ...result,
-            target: session.result.data.target,
-            name: session.result.data.stepName,
-            dependsOn: session.result.data.dependsOn,
-          };
-        }
-        res.status(session.statusCode).json(result);
-      } catch (error) {
-        console.log(error);
-        return next(error);
-      }
-    }
-  );
-
   router
     .route('/:sessionId')
     .options(common.cors())
@@ -97,6 +58,7 @@ const createSessionRouter = (SessionService: SessionedEntityService<any, any>) =
           const result = {
             id: req.params.sessionId,
             input: session.result.data.input,
+            output: session.result.data.output,
             dependsOn: session.result.data.dependsOn,
           };
           res.status(session.statusCode).json(result);

--- a/api/function-api/src/routes/schema/subcomponent.ts
+++ b/api/function-api/src/routes/schema/subcomponent.ts
@@ -11,7 +11,7 @@ import Validation from '../validation/component';
 
 import query from '../handlers/query';
 
-import { BaseEntityService } from '../service';
+import { BaseEntityService, operationService } from '../service';
 import CommonTagRouter from './common/tag';
 import CommonCrudRouter from './common/crud';
 
@@ -21,10 +21,6 @@ const subcomponentRouter = (
   parentEntityType: Model.EntityType
 ) => {
   const router = express.Router({ mergeParams: true });
-
-  const createPath = (endpoint: string = '') => {
-    return `/:${idParamNames[0]}/${service.entityType}/:${idParamNames[1]}${endpoint || ''}`;
-  };
 
   router.use(analytics.setModality(analytics.Modes.Administration));
   router
@@ -43,6 +39,20 @@ const subcomponentRouter = (
             subscriptionId: req.params.subscriptionId,
             id: req.params.entityId,
           });
+
+          if (req.query.operationId) {
+            const status = await operationService.getInstanceByOperation(
+              req.params as { accountId: string; subscriptionId: string },
+              req.query.operationId as string,
+              req.params.entityId
+            );
+
+            if (status.statusCode === 200 && typeof status.result === 'object') {
+              return res.json({ total: 1, items: [Model.entityToSdk(status.result)] });
+            }
+
+            return res.status(status.statusCode).json({ message: status.result });
+          }
 
           const response = await service.dao.listEntities(
             {
@@ -87,6 +97,10 @@ const subcomponentRouter = (
         }
       }
     );
+
+  const createPath = (endpoint: string = '') => {
+    return `/:${idParamNames[0]}/${service.entityType}/:${idParamNames[1]}${endpoint || ''}`;
+  };
 
   router.use(createPath('/tag'), CommonTagRouter(service, idParamNames));
   router.use(createPath(), CommonCrudRouter(service, idParamNames));

--- a/api/function-api/src/routes/service/BaseEntityService.ts
+++ b/api/function-api/src/routes/service/BaseEntityService.ts
@@ -1,7 +1,7 @@
 import { IAgent } from '@5qtrs/account-data';
 import { Model } from '@5qtrs/db';
 
-import { operationService } from './OperationService';
+import { operationService, OperationVerbs } from './OperationService';
 import * as Function from '../functions';
 
 export const defaultFrameworkSemver = '^3.0.0';
@@ -77,7 +77,7 @@ export default abstract class BaseEntityService<E extends Model.IEntity, F exten
     return operationService.inOperation(
       this.entityType,
       entity,
-      { verb: 'creating', type: this.entityType },
+      { verb: OperationVerbs.creating, type: this.entityType },
       async () => {
         entity = this.sanitizeEntity(entity);
         await this.createEntityOperation(entity);
@@ -109,7 +109,7 @@ export default abstract class BaseEntityService<E extends Model.IEntity, F exten
     return operationService.inOperation(
       this.entityType,
       entity,
-      { verb: 'updating', type: this.entityType },
+      { verb: OperationVerbs.updating, type: this.entityType },
       async () => {
         // Make sure the entity already exists.
         await this.dao.getEntity(entity);
@@ -129,7 +129,7 @@ export default abstract class BaseEntityService<E extends Model.IEntity, F exten
     return operationService.inOperation(
       this.entityType,
       entity,
-      { verb: 'deleting', type: this.entityType },
+      { verb: OperationVerbs.deleting, type: this.entityType },
       async () => {
         try {
           // Do delete things - create functions, collect their versions, and update the entity.data object

--- a/api/function-api/src/routes/service/ConnectorService.ts
+++ b/api/function-api/src/routes/service/ConnectorService.ts
@@ -83,11 +83,6 @@ class ConnectorService extends SessionedEntityService<Model.IConnector, Model.II
           resource: '/account/{{accountId}}/subscription/{{subscriptionId}}/{{boundaryId}/{{functionId}}/session/',
         },
         {
-          action: v2Permissions.getSessionResult,
-          resource:
-            '/account/{{accountId}}/subscription/{{subscriptionId}}/{{boundaryId}/{{functionId}}/session/result/',
-        },
-        {
           action: v2Permissions.getSession,
           resource: '/account/{{accountId}}/subscription/{{subscriptionId}}/{{boundaryId}/{{functionId}}/session/',
         },

--- a/api/function-api/src/routes/service/IntegrationService.ts
+++ b/api/function-api/src/routes/service/IntegrationService.ts
@@ -118,11 +118,6 @@ class IntegrationService extends SessionedEntityService<Model.IIntegration, Mode
           resource: '/account/{{accountId}}/subscription/{{subscriptionId}}/{{boundaryId}/{{functionId}}/session/',
         },
         {
-          action: v2Permissions.getSessionResult,
-          resource:
-            '/account/{{accountId}}/subscription/{{subscriptionId}}/{{boundaryId}/{{functionId}}/session/result/',
-        },
-        {
           action: v2Permissions.getSession,
           resource: '/account/{{accountId}}/subscription/{{subscriptionId}}/{{boundaryId}/{{functionId}}/session/',
         },

--- a/api/function-api/src/routes/service/OperationService.ts
+++ b/api/function-api/src/routes/service/OperationService.ts
@@ -1,18 +1,24 @@
 import http_error from 'http-errors';
 import { v4 as uuidv4 } from 'uuid';
 
-import { isUuid } from '@5qtrs/constants';
+import { isUuid, API_PUBLIC_ENDPOINT } from '@5qtrs/constants';
 import RDS, { Model } from '@5qtrs/db';
 
 import { IServiceResult } from './BaseEntityService';
 
+export enum OperationVerbs {
+  creating = 'creating',
+  updating = 'updating',
+  deleting = 'deleting',
+}
+
 interface IOperationParam {
-  verb: 'creating' | 'updating' | 'deleting';
+  verb: OperationVerbs;
   type: Model.EntityType;
 }
 
 interface IOperationData extends IOperationParam {
-  code: number; // HTTP status codes
+  statusCode: number; // HTTP status codes
   message?: string;
   location: {
     accountId: string;
@@ -40,23 +46,14 @@ class OperationService {
 
     // Create operation with the status
     const operationId = uuidv4();
-    const isCompositeId = entity.id && entity.id.includes('/');
-
-    const entityId = isCompositeId ? Model.decomposeSubordinateId(entity.id).parentEntityId : entity.id;
-
-    // Is it a non-empty actual number? If so, it's probably a database id - don't use it. This continues the
-    // efforts of trying to avoid exposing session, identity, instance, and database id's out through these APIs.
-    if (isCompositeId && (!isNaN(+entityId) || !isNaN(parseFloat(entityId)) || isUuid(entityId))) {
-      throw http_error(500, 'Invalid entityId detected');
-    }
 
     const operation: IOperationData = {
       ...status,
-      code: 202,
+      statusCode: 202,
       location: {
         accountId: entity.accountId,
         subscriptionId: entity.subscriptionId,
-        entityId,
+        entityId: entity.id,
         entityType,
       },
     };
@@ -77,23 +74,27 @@ class OperationService {
         const payload = await op(operationId);
 
         if (payload) {
-          operationEntity.data.code = payload.statusCode;
+          operationEntity.data.statusCode = payload.statusCode;
           operationEntity.data.payload = payload.result;
         } else {
-          operationEntity.data.code = 200;
+          operationEntity.data.statusCode = 200;
         }
       } catch (err) {
         if (err.message && err.message.match(/duplicate key value/)) {
-          operationEntity.data = { ...operation, code: 400, message: `Duplicate key value: ${entity.id}` };
+          operationEntity.data = { ...operation, statusCode: 400, message: `Duplicate key value: ${entity.id}` };
         } else {
           // Update operation with the error message
-          operationEntity.data = { ...operation, code: err.status || err.statusCode || 500, message: err.message };
+          operationEntity.data = {
+            ...operation,
+            statusCode: err.status || err.statusCode || 500,
+            message: err.message,
+          };
         }
       }
 
       console.log(
         `OPR /v2/account/${entity.accountId}/subscription/${entity.subscriptionId}/operation/${operationId} ${
-          operationEntity.data.code
+          operationEntity.data.statusCode
         } - ${status.verb} ${status.type} ${entity.id} ${
           operationEntity.data.message ? `: ${operationEntity.data.message}` : ''
         }`
@@ -102,7 +103,126 @@ class OperationService {
     });
 
     // Return operation with operationId populated
-    return { statusCode: 202, result: { operationId } };
+    const baseUrl = `${API_PUBLIC_ENDPOINT}/v2/account/${entity.accountId}/subscription/${entity.subscriptionId}`;
+
+    let target;
+    const statusOnly = `${baseUrl}/operation/${operationId}`;
+
+    switch (entityType) {
+      case Model.EntityType.session:
+        const integrationId = Model.decomposeSubordinateId(entity.id).parentEntityId;
+        target = `${baseUrl}/integration/${integrationId}/instance?operationId=${operationId}`;
+        break;
+      case Model.EntityType.integration:
+        target = `${baseUrl}/integration?operationId=${operationId}`;
+        break;
+      case Model.EntityType.connector:
+        target = `${baseUrl}/connector?operationId=${operationId}`;
+        break;
+    }
+
+    return { statusCode: 202, result: { operationId, target, statusOnly } };
+  };
+
+  public getInstanceByOperation = async (
+    params: {
+      accountId: string;
+      subscriptionId: string;
+    },
+    operationId: string,
+    integrationId: string
+  ): Promise<{ statusCode: number; result: Model.IInstance | string | undefined }> => {
+    // Look up an instance via a session
+    if (!integrationId) {
+      throw http_error(400, 'Missing integration');
+    }
+
+    // Get the operation to validate it's pointed at the expected object class and type
+    const operation = await this.dao.getEntity({
+      accountId: params.accountId,
+      subscriptionId: params.subscriptionId,
+      id: operationId,
+    });
+
+    if (operation.data.location.entityType !== Model.EntityType.session) {
+      throw http_error(404);
+    }
+
+    // If the operation is errored, incomplete, or doesn't apply to an entity, return with that status
+    if (operation.data.statusCode !== 200 || !operation.data.location.entityId) {
+      return { statusCode: operation.data.statusCode, result: operation.data.message };
+    }
+
+    // Load the session specified in the operation
+    const session = await RDS.DAO[Model.EntityType.session].getEntity({
+      accountId: params.accountId,
+      subscriptionId: params.subscriptionId,
+      id: operation.data.location.entityId,
+    });
+
+    // Fetch the parent, to filter for instances under this integration
+    const parentEntity = await RDS.DAO[Model.EntityType.integration].getEntity({
+      accountId: params.accountId,
+      subscriptionId: params.subscriptionId,
+      id: integrationId,
+    });
+    if (!parentEntity.__databaseId) {
+      throw http_error(500, 'Missing id');
+    }
+
+    // Load the instance using the instanceId from the session.data.output
+    const instanceId = session.data.output.entityId;
+    if (!instanceId) {
+      return { statusCode: 404, result: 'instance not found' };
+    }
+
+    const instance = await RDS.DAO[Model.EntityType.instance].getEntity({
+      accountId: params.accountId,
+      subscriptionId: params.subscriptionId,
+      id: Model.createSubordinateId(Model.EntityType.integration, parentEntity.__databaseId, instanceId),
+    });
+
+    return { statusCode: 200, result: instance };
+  };
+
+  public getEntityByOperation = async (
+    params: {
+      accountId: string;
+      subscriptionId: string;
+    },
+    operationId: string,
+    entityType: Model.EntityType
+  ): Promise<{ statusCode: number; result: Model.IIntegration | Model.IConnector | string | undefined }> => {
+    if (entityType !== Model.EntityType.connector && entityType !== Model.EntityType.integration) {
+      throw http_error(500, `Invalid entity type '${entityType}' for operation '${operationId}'`);
+    }
+
+    // Get the operation to validate it's pointed at the expected object class and type
+    const operation = await this.dao.getEntity({
+      accountId: params.accountId,
+      subscriptionId: params.subscriptionId,
+      id: operationId,
+    });
+
+    if (operation.data.location.entityType !== entityType) {
+      throw http_error(404);
+    }
+    // If the operation is errored, incomplete, or doesn't apply to an entity, return with that status
+    if (operation.data.statusCode !== 200 || !operation.data.location.entityId) {
+      return { statusCode: operation.data.statusCode, result: operation.data.message };
+    }
+
+    if (operation.data.verb === OperationVerbs.deleting) {
+      return { statusCode: 200, result: undefined };
+    }
+
+    const entity = await RDS.DAO[entityType].getEntity({
+      accountId: params.accountId,
+      subscriptionId: params.subscriptionId,
+      id: operation.data.location.entityId,
+    });
+
+    return { statusCode: 200, result: entity };
   };
 }
 

--- a/api/function-api/src/routes/service/SessionedEntityService.ts
+++ b/api/function-api/src/routes/service/SessionedEntityService.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import RDS, { Model } from '@5qtrs/db';
 
 import BaseEntityService, { IServiceResult } from './BaseEntityService';
-import { operationService } from './OperationService';
+import { operationService, OperationVerbs } from './OperationService';
 
 export default abstract class SessionedEntityService<
   E extends Model.IEntity,
@@ -165,7 +165,7 @@ export default abstract class SessionedEntityService<
         return acc;
       }, {});
 
-    let replacementTargetId: string | undefined = undefined;
+    let replacementTargetId: string | undefined;
     let previousOutput;
     if (!!parentSession.data.replacementTargetId && !!instance) {
       if (step.entityType === Model.EntityType.integration) {
@@ -273,6 +273,7 @@ export default abstract class SessionedEntityService<
 
     // Get instance if needed
     const instance = await this.getSessionInstance(parentSession);
+
     // Get the first step
     const step = parentSession.data.components[0];
 
@@ -341,8 +342,8 @@ export default abstract class SessionedEntityService<
     return operationService.inOperation(
       Model.EntityType.session,
       entity,
-      { verb: 'creating', type: Model.EntityType.session },
-      async (operationId) => {
+      { verb: OperationVerbs.creating, type: Model.EntityType.session },
+      async (operationId: string) => {
         const session = await this.sessionDao.getEntity(entity);
         this.ensureSessionTrunk(session, 'cannot post non-master session', 400);
         session.data.operationId = operationId;

--- a/api/function-api/src/routes/service/index.ts
+++ b/api/function-api/src/routes/service/index.ts
@@ -4,3 +4,4 @@ export { default as ConnectorService } from './ConnectorService';
 export { default as IntegrationService } from './IntegrationService';
 export { default as InstanceService } from './InstanceService';
 export { default as IdentityService } from './IdentityService';
+export { operationService } from './OperationService';

--- a/api/function-api/src/routes/validation/entities.ts
+++ b/api/function-api/src/routes/validation/entities.ts
@@ -46,6 +46,7 @@ const EntityIdQuery = Joi.object().keys({
   next: Joi.string(),
   tag: Common.tagQuery,
   defaults: Joi.boolean(),
+  operationId: Joi.string().guid(),
 });
 
 // Add validation that the filename can't start with leading '.'... how to make sure it's safe for windows,

--- a/api/function-api/src/routes/validation/operation.ts
+++ b/api/function-api/src/routes/validation/operation.ts
@@ -5,7 +5,7 @@ import * as Common from './common';
 export const OperationEntry = Joi.object().keys({
   verb: Joi.string().required(),
   type: Joi.string().required(),
-  code: Joi.number().required(),
+  statusCode: Joi.number().required(),
   message: Joi.string().optional(),
   location: Joi.object()
     .keys({

--- a/api/function-api/test/v2/crud.test.ts
+++ b/api/function-api/test/v2/crud.test.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
 });
 afterAll(async () => {
   await cleanupEntities(account);
-}, 30000);
+}, 180000);
 
 // Types
 type TestableEntityTypes = Extract<Model.EntityType, Model.EntityType.connector | Model.EntityType.integration>;
@@ -122,12 +122,33 @@ const setFiles = (entity: Model.ISdkEntity, newFiles: Record<string, string>, ha
 };
 
 const createEntity = async (testEntityType: TestableEntityTypes, entity: Model.ISdkEntity) => {
+  const basePath = `/v2/account/${account.accountId}/subscription/${account.subscriptionId}`;
   const createResponse = await ApiRequestMap[testEntityType].post(account, entity);
   expect(createResponse).toBeHttp({ statusCode: 202 });
+  expect(createResponse.data.target).toMatch(
+    new RegExp(`${basePath}/${testEntityType}\\?operationId=${createResponse.data.operationId}$`)
+  );
+  expect(createResponse.data.statusOnly).toMatch(
+    new RegExp(`${basePath}/operation/${createResponse.data.operationId}$`)
+  );
+
+  let result = await ApiRequestMap[testEntityType].list(account, { operation: createResponse.data.operationId });
+  expect(result).toBeHttp({ statusCode: 202 });
+  expect(result.data).toStrictEqual({});
+
   const operation = await ApiRequestMap.operation.waitForCompletion(account, createResponse.data.operationId);
   expect(operation).toBeHttp({ statusCode: 200 });
+
+  // Check that the list action using an operation key produces the expected entity
+  result = await ApiRequestMap[testEntityType].list(account, { operation: createResponse.data.operationId });
+  expect(result).toBeHttp({ statusCode: 200, data: { total: 1 } });
+  expect(result.data.items.length).toBe(1);
+  expect(result.data.items[0]).toExtend(entity);
+  expect(result.data.items[0].version).toBeUUID();
+
+  // Check that the list operation with the specified prefix produces the expected entity
   const listResponse = await ApiRequestMap[testEntityType].list(account, getIdPrefix());
-  expect(listResponse).toBeHttp({ statusCode: 200 });
+  expect(listResponse).toBeHttp({ statusCode: 200, data: { total: 1 } });
   expect(listResponse.data).toBeDefined();
   expect(listResponse.data.items.length).toBe(1);
   expect(listResponse.data.items[0]).toExtend(entity);
@@ -157,6 +178,19 @@ const performTests = (testEntityType: TestableEntityTypes, sampleEntityMap: Samp
     const createResponseConflict = await ApiRequestMap[testEntityType].post(account, entity);
     const operation = await ApiRequestMap.operation.waitForCompletion(account, createResponseConflict.data.operationId);
     expect(operation).toBeHttp({ statusCode: 400 });
+  }, 180000);
+
+  test('Operation reports 400 on LIST endpoint', async () => {
+    let result;
+    const entity = sampleEntity();
+    await createEntityTest(entity);
+
+    const createResponseConflict = await ApiRequestMap[testEntityType].post(account, entity);
+    result = await ApiRequestMap.operation.waitForCompletion(account, createResponseConflict.data.operationId);
+    expect(result).toBeHttp({ statusCode: 400, data: { message: `Duplicate key value: ${entity.id}` } });
+
+    result = await ApiRequestMap[testEntityType].list(account, { operation: createResponseConflict.data.operationId });
+    expect(result).toBeHttp({ statusCode: 400, data: { message: `Duplicate key value: ${entity.id}` } });
   }, 180000);
 
   test('Update Entity', async () => {

--- a/api/function-api/test/v2/sdk.ts
+++ b/api/function-api/test/v2/sdk.ts
@@ -1,7 +1,8 @@
 import { IAccount } from './accountResolver';
 import { request } from '@5qtrs/request';
-import { Model } from '@5qtrs/db';
+import RDS, { Model } from '@5qtrs/db';
 import * as querystring from 'querystring';
+import { OperationVerbs } from '../../src/routes/service/OperationService';
 
 import { getEnv } from '../v1/setup';
 
@@ -14,6 +15,7 @@ export interface IRequestOptions {
   contentType?: string;
   body?: string | object;
   authz?: string;
+  rawUrl?: boolean;
 }
 
 export interface IDispatchOptions {
@@ -53,11 +55,73 @@ export const v2Request = async (account: IAccount, options: IRequestOptions) => 
       'user-agent': account.userAgent,
       ...(options.contentType ? { 'content-type': options.contentType } : {}),
     },
-    url: `${account.baseUrl}/v2/account/${account.accountId}/subscription/${account.subscriptionId}${options.uri}`,
+    url: options.rawUrl
+      ? options.uri
+      : `${account.baseUrl}/v2/account/${account.accountId}/subscription/${account.subscriptionId}${options.uri}`,
     method: options.method,
     data: options.body,
     maxRedirects: options.maxRedirects,
   });
+};
+
+export const validateOperation = (
+  account: IAccount,
+  opRequest: any,
+  entityType: Model.EntityType,
+  entityId?: string
+) => {
+  const basePath = `/v2/account/${account.accountId}/subscription/${account.subscriptionId}`;
+  let targetPath = `${basePath}`;
+  if (entityId) {
+    // Only sessions supply this right now
+    expect(entityType).toBe(Model.EntityType.integration);
+    expect(entityId).not.toBeUndefined();
+    targetPath += `/${entityType}/${entityId}/instance\\?operationId=${opRequest.data.operationId}$`;
+  } else {
+    targetPath += `/${entityType}\\?operationId=${opRequest.data.operationId}$`;
+  }
+
+  expect(opRequest.data.target).toMatch(new RegExp(targetPath));
+  expect(opRequest.data.statusOnly).toMatch(new RegExp(`${basePath}/operation/${opRequest.data.operationId}$`));
+};
+
+export const compareOperationTargets = async (account: IAccount, targets: { target: string; statusOnly: string }) => {
+  let listOp: any;
+  let opOp: any;
+
+  let tries = 3;
+  do {
+    tries = tries - 1;
+    // Check the targetUrl is now correctly updated
+    listOp = await v2Request(account, {
+      method: 'GET',
+      uri: targets.target,
+      rawUrl: true,
+    });
+
+    opOp = await v2Request(account, {
+      method: 'GET',
+      uri: targets.statusOnly,
+      rawUrl: true,
+    });
+
+    if (tries <= 0) {
+      expect(listOp.status).toBe(opOp.status);
+    }
+
+    // Race conditions; just making sure they eventually converge here.
+  } while (listOp.status !== opOp.status);
+
+  const isDeleting = opOp.data.verb === OperationVerbs.deleting;
+
+  expect(listOp).toBeHttp({ statusCode: opOp.status });
+  if (listOp.status === 200) {
+    expect(listOp.data.total).toBe(isDeleting ? 0 : 1);
+    expect(listOp.data.items.length).toBe(isDeleting ? 0 : 1);
+    if (!isDeleting && targets.target.match(/\/instance\//)) {
+      expect(listOp.data.items[0].id).toBeUUID();
+    }
+  }
 };
 
 export const ApiRequestMap: { [key: string]: any } = {
@@ -81,15 +145,11 @@ export const ApiRequestMap: { [key: string]: any } = {
         return response;
       },
       getResult: async (account: IAccount, entityId: string, sessionId: string, options?: IRequestOptions) => {
-        const response = await v2Request(account, {
-          method: 'GET',
-          uri: `/connector/${encodeURI(entityId)}/session/${sessionId}/result`,
-          ...options,
+        return RDS.DAO.session.getEntity({
+          accountId: account.accountId,
+          subscriptionId: account.subscriptionId,
+          id: Model.createSubordinateId(Model.EntityType.connector, entityId, sessionId),
         });
-        if (response.status < 300) {
-          expect(response.data.id).not.toMatch('/');
-        }
-        return response;
       },
       get: async (account: IAccount, entityId: string, sessionId: string, options?: IRequestOptions) => {
         const response = await v2Request(account, {
@@ -137,7 +197,13 @@ export const ApiRequestMap: { [key: string]: any } = {
 
     list: async (
       account: IAccount,
-      query?: { tag?: { tagKey: string; tagValue?: string }; limit?: number; next?: string; idPrefix?: string },
+      query?: {
+        tag?: { tagKey: string; tagValue?: string };
+        limit?: number;
+        next?: string;
+        idPrefix?: string;
+        operation?: string;
+      },
       options?: IRequestOptions
     ) => {
       const tagString = query?.tag?.tagValue ? `${query.tag.tagKey}=${query.tag.tagValue}` : query?.tag?.tagKey;
@@ -163,7 +229,19 @@ export const ApiRequestMap: { [key: string]: any } = {
     ) => {
       const op = await ApiRequestMap.connector.post(account, body);
       expect(op).toBeHttp({ statusCode: 202 });
-      return ApiRequestMap.operation.waitForCompletion(account, op.data.operationId, waitOptions, options);
+      validateOperation(account, op, Model.EntityType.connector);
+
+      await compareOperationTargets(account, op.data);
+
+      const completed = await ApiRequestMap.operation.waitForCompletion(
+        account,
+        op.data.operationId,
+        waitOptions,
+        options
+      );
+      await compareOperationTargets(account, op.data);
+
+      return completed;
     },
 
     put: async (account: IAccount, connectorId: string, body: Model.ISdkEntity, options?: IRequestOptions) =>
@@ -178,7 +256,18 @@ export const ApiRequestMap: { [key: string]: any } = {
     ) => {
       const op = await ApiRequestMap.connector.put(account, connectorId, body);
       expect(op).toBeHttp({ statusCode: 202 });
-      return ApiRequestMap.operation.waitForCompletion(account, op.data.operationId, waitOptions, options);
+      validateOperation(account, op, Model.EntityType.connector);
+
+      await compareOperationTargets(account, op.data);
+
+      const completed = await ApiRequestMap.operation.waitForCompletion(
+        account,
+        op.data.operationId,
+        waitOptions,
+        options
+      );
+      await compareOperationTargets(account, op.data);
+      return completed;
     },
 
     delete: async (account: IAccount, connectorId: string, options?: IRequestOptions) =>
@@ -194,13 +283,18 @@ export const ApiRequestMap: { [key: string]: any } = {
       do {
         const op = await ApiRequestMap.connector.delete(account, entityId);
         expect(op).toBeHttp({ statusCode: 202 });
+        validateOperation(account, op, Model.EntityType.connector);
+
+        await compareOperationTargets(account, op.data);
+
         wait = await ApiRequestMap.operation.waitForCompletion(
           account,
           op.data.operationId,
           { ...waitOptions, getAfter: false },
           options
         );
-      } while (wait.status === 428);
+        await compareOperationTargets(account, op.data);
+      } while (wait.status === 429);
 
       return wait;
     },
@@ -250,15 +344,11 @@ export const ApiRequestMap: { [key: string]: any } = {
         return response;
       },
       getResult: async (account: IAccount, entityId: string, sessionId: string, options?: IRequestOptions) => {
-        const response = await v2Request(account, {
-          method: 'GET',
-          uri: `/integration/${encodeURI(entityId)}/session/${sessionId}/result`,
-          ...options,
+        return RDS.DAO.session.getEntity({
+          accountId: account.accountId,
+          subscriptionId: account.subscriptionId,
+          id: Model.createSubordinateId(Model.EntityType.integration, entityId, sessionId),
         });
-        if (response.status < 300) {
-          expect(response.data.id).not.toMatch('/');
-        }
-        return response;
       },
       get: async (account: IAccount, entityId: string, sessionId: string, options?: IRequestOptions) => {
         const response = await v2Request(account, {
@@ -312,12 +402,20 @@ export const ApiRequestMap: { [key: string]: any } = {
           ...options,
         });
         expect(op).toBeHttp({ statusCode: 202 });
-        return ApiRequestMap.operation.waitForCompletion(
+        validateOperation(account, op, Model.EntityType.integration, entityId);
+
+        // Sessions complete too fast to be able to do `compareOperationTargets` here.
+
+        const completed = await ApiRequestMap.operation.waitForCompletion(
           account,
           op.data.operationId,
           { ...waitOptions, getAfter: false },
           options
         );
+
+        compareOperationTargets(account, op.data);
+
+        return completed;
       },
     },
 
@@ -327,7 +425,13 @@ export const ApiRequestMap: { [key: string]: any } = {
 
     list: async (
       account: IAccount,
-      query?: { tag?: { tagKey: string; tagValue?: string }; limit?: number; next?: string; idPrefix?: string },
+      query?: {
+        tag?: { tagKey: string; tagValue?: string };
+        limit?: number;
+        next?: string;
+        idPrefix?: string;
+        operation?: string;
+      },
       options?: IRequestOptions
     ) => {
       const tagString = query?.tag?.tagValue ? `${query.tag.tagKey}=${query.tag.tagValue}` : query?.tag?.tagKey;
@@ -357,7 +461,18 @@ export const ApiRequestMap: { [key: string]: any } = {
     ) => {
       const op = await ApiRequestMap.integration.post(account, body);
       expect(op).toBeHttp({ statusCode: 202 });
-      return ApiRequestMap.operation.waitForCompletion(account, op.data.operationId, waitOptions, options);
+      validateOperation(account, op, Model.EntityType.integration);
+
+      await compareOperationTargets(account, op.data);
+
+      const completed = await ApiRequestMap.operation.waitForCompletion(
+        account,
+        op.data.operationId,
+        waitOptions,
+        options
+      );
+      await compareOperationTargets(account, op.data);
+      return completed;
     },
 
     put: async (account: IAccount, integrationId: string, body: Model.ISdkEntity, options?: IRequestOptions) =>
@@ -371,7 +486,18 @@ export const ApiRequestMap: { [key: string]: any } = {
     ) => {
       const op = await ApiRequestMap.integration.put(account, integrationId, body);
       expect(op).toBeHttp({ statusCode: 202 });
-      return ApiRequestMap.operation.waitForCompletion(account, op.data.operationId, waitOptions, options);
+      validateOperation(account, op, Model.EntityType.integration);
+
+      await compareOperationTargets(account, op.data);
+
+      const completed = await ApiRequestMap.operation.waitForCompletion(
+        account,
+        op.data.operationId,
+        waitOptions,
+        options
+      );
+      await compareOperationTargets(account, op.data);
+      return completed;
     },
 
     delete: async (account: IAccount, integrationId: string, options?: IRequestOptions) =>
@@ -385,12 +511,18 @@ export const ApiRequestMap: { [key: string]: any } = {
     ) => {
       const op = await ApiRequestMap.integration.delete(account, entityId);
       expect(op).toBeHttp({ statusCode: 202 });
-      return ApiRequestMap.operation.waitForCompletion(
+      validateOperation(account, op, Model.EntityType.integration);
+
+      await compareOperationTargets(account, op.data);
+
+      const completed = await ApiRequestMap.operation.waitForCompletion(
         account,
         op.data.operationId,
         { ...waitOptions, getAfter: false },
         options
       );
+      await compareOperationTargets(account, op.data);
+      return completed;
     },
 
     dispatch: async (

--- a/api/function-api/test/v2/session.errors.test.ts
+++ b/api/function-api/test/v2/session.errors.test.ts
@@ -46,7 +46,8 @@ describe('Sessions', () => {
       headers: { location: `${demoRedirectUrl}/?error=bad_monkey&errorDescription=worst&session=${parentSessionId}` },
     });
 
-    // Post and check the session to see that the result is an error
+    // Post and check the session to see that the result is an error, generates "Missing child session id"
+    // warnings in function-api that probably need to be squelched at some point
     response = await ApiRequestMap.integration.session.postSession(account, integrationId, parentSessionId);
     expect(response).toBeHttp({ statusCode: 400 });
     expect(response.data.message).toMatch(/bad_monkey/);

--- a/lib/constants/src/permissions.ts
+++ b/lib/constants/src/permissions.ts
@@ -68,7 +68,6 @@ export const v2Permissions: Record<any, any> = {
   postSession: 'session:post',
   putSession: 'session:put',
   getSession: 'session:get',
-  getSessionResult: 'session:result',
   commitSession: 'session:commit',
 };
 

--- a/lib/data/ops-data-aws/test_plsql/env.benn.dev
+++ b/lib/data/ops-data-aws/test_plsql/env.benn.dev
@@ -1,4 +1,4 @@
-AWS_PROFILE=fusestage
+AWS_PROFILE=fusebit.stage
 REGION=us-west-1
 SECRET_ARN=arn:aws:secretsmanager:us-west-1:749775346857:secret:rds-db-credentials/fusebit-db-secret-benn-3a0aa0a9ee63a1de9087-qmVaRo
 DATABASE_ARN=arn:aws:rds:us-west-1:749775346857:cluster:fusebit-db-benn

--- a/lib/data/schema/src/index.ts
+++ b/lib/data/schema/src/index.ts
@@ -124,7 +124,7 @@ export interface IOperation extends IEntity {
   data: {
     verb: 'creating' | 'updating' | 'deleting';
     type: EntityType;
-    code: number; // HTTP status codes
+    statusCode: number; // HTTP status codes
     message?: string;
     payload?: any;
     location: {

--- a/lib/server/function-lambda/src/delete_function.js
+++ b/lib/server/function-lambda/src/delete_function.js
@@ -13,7 +13,7 @@ export function delete_function(req, res, next) {
         return next(create_error(404));
       }
       if (e.code === 'TooManyRequestsException') {
-        return next(create_error(428, `Error deleting function: ${e.message}.`));
+        return next(create_error(429, `Error deleting function: ${e.message}.`));
       }
       return next(create_error(500, `Error deleting function: ${e.message}.`));
     }


### PR DESCRIPTION
This PR contains a tactical rethink on how the session handling process works, largely on how sessions are committed and the necessary calls to perform afterwards.

### Change to operation polling

The process now looks as follows (this is highlighted for instance creation through sessions, but is true for all cases where operations are used including connector and integration creation):
1. POST /integration/id/session/sid
```
{
  operationId: '282ab0e9-8f78-46c2-b5f1-b3b6e19a6c8b',
  target: 'http://localhost:3001/v2/a/s/i/int-123/instance?operation=282ab0e9-8f78-46c2-b5f1-b3b6e19a6c8b',
  statusOnly: 'http://localhost:3001/v2/a/s/operation/282ab0e9-8f78-46c2-b5f1-b3b6e19a6c8b'
}
```
2. GET `http://localhost:3001/v2/a/s/i/int-123/instance?operation=282ab0e9-8f78-46c2-b5f1-b3b6e19a6c8b`
```
202 HTTP/1.1
```
...
```
200 HTTP/1.1

{
      "total": 1,
      "items": [
        {
          "id": "f3f9ed27-7b89-45d2-b3da-7f102cb04112",
          "data": {
            "conn": {
              "tags": {
                "session.master": "06576e70-1c89-4d60-a9a5-9f2c0be76e64"
              },
              "entityId": "daa93e23-dde7-4720-96a9-9d69f9f9fc68",
              "accountId": "acc-12d136912f0c4912",
              "entityType": "identity",
              "parentEntityId": "test-session-206-301251475-con",
              "subscriptionId": "sub-a447d98de09c4cfe",
              "parentEntityType": "connector"
            },
            "form": {
              "newData": "for instance"
            }
          },
          "tags": {
            "session.master": "06576e70-1c89-4d60-a9a5-9f2c0be76e64"
          },
          "version": "82b1e0bc-e0b3-4b17-b305-fad852745523"
        }
      ]
    }
```
Similar results for `/integration?operation=...` and `/connector?operation=...` endpoints are also available.

The `statusOnly` url is there to be passed on to the untrusted frontend for driving progress bars or spinners, whereas the result of a GET operation on the `target` url is output identical to that of a search operation on the same endpoint.  All three search endpoints - integrations, connectors, and instances - support an `operation` parameter for getting the resulting integration, connector, or instance respectively.

### Removal of the `/session/:id/result` call

The /session/id/result call is removed completely, with the `output` field being returned on a `GET /session/sid` operation.  This was originally segregated for security reasons, but because the `GET /session/sid` was already a permissioned operation, the value diminished. Having a separate call didn't seem as warranted, though the author welcomes additional perspectives.

The primary use of this was in the test code, which has been replaced with a direct database lookup for similar levels of validation.

Uses from within an integration will be satisfied by the `GET /session/:id` call providing the output parameters of a previous operation, if the permissions allow.

### Rename of operation.code to operation.statusCode

It seemed to be a much more consistent naming convention, so the opportunity was taken to remove the outlier.

### Change a delete_function TooManyRequestsException to 429

Somehow it was a 428 error code, almost certainly due to clumsy fingers by some unnamed fool.