### PR TITLE
[1]. Secure /api/token connector endpoints

### DIFF
--- a/api/function-api/src/routes/functions.ts
+++ b/api/function-api/src/routes/functions.ts
@@ -194,11 +194,11 @@ const deleteFunction = async (params: IParams): Promise<any> => {
 
 const checkAuthorization = async (
   accountId: string,
-  functionSummary: string,
-  authToken?: string | undefined,
-  operation?: { operation: string; path: string }
-) => {
-  const authentication = Constants.getFunctionAuthentication(functionSummary);
+  authToken: string | undefined,
+  authentication: string | undefined,
+  subset?: { action: string; resource: string }[],
+  operation?: { action: string; resource: string }
+): Promise<IAgent | undefined> => {
   if (!authentication || authentication === 'none' || (authentication === 'optional' && !authToken)) {
     return undefined;
   }
@@ -207,21 +207,19 @@ const checkAuthorization = async (
     const resolvedAgent = await getResolvedAgent(accountId, authToken);
 
     if (operation) {
-      const resource = operation.path;
-      const action = operation.operation;
+      await resolvedAgent.ensureAuthorized(operation.action, operation.resource);
 
-      await resolvedAgent.ensureAuthorized(action, resource);
+      return resolvedAgent;
+    } else if (subset) {
+      await resolvedAgent.checkPermissionSubset({ allow: subset });
     }
-
-    const functionAuthz = Constants.getFunctionAuthorization(functionSummary);
-    await resolvedAgent.checkPermissionSubset({ allow: functionAuthz });
 
     return resolvedAgent;
   } catch (error) {
     if (authentication === 'optional') {
       return undefined;
     }
-    throw Error(error);
+    throw error;
   }
 };
 
@@ -244,13 +242,14 @@ const executeFunction = async (
 
   const functionSummary = await loadFunctionSummary(params);
   const functionAuthz = Constants.getFunctionAuthorization(functionSummary);
+  const functionAuthn = Constants.getFunctionAuthentication(functionSummary);
   const functionPerms = Constants.getFunctionPermissions(functionSummary);
 
   // Guarantee a release regardless of the exceptions that occur later by using a finally{} clause to call
   // the releaseRate function.
   const releaseRate = ratelimit.checkRateLimit(sub, params.subscriptionId);
   try {
-    const resolvedAgent = await checkAuthorization(params.accountId, functionSummary, options.token, undefined);
+    const resolvedAgent = await checkAuthorization(params.accountId, options.token, functionAuthn, functionAuthz);
 
     // execute
     const baseUrl = Constants.get_function_location({}, params.subscriptionId, params.boundaryId, params.functionId);
@@ -293,6 +292,7 @@ export {
   createFunction,
   deleteFunction,
   executeFunction,
+  checkAuthorization,
   waitForFunctionBuild,
   IFunctionSpecification,
   IExecuteFunction,

--- a/api/function-api/src/routes/schema/common/root.ts
+++ b/api/function-api/src/routes/schema/common/root.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 
+import { IAgent } from '@5qtrs/account-data';
 import { Model } from '@5qtrs/db';
 import { v2Permissions } from '@5qtrs/constants';
 
@@ -86,9 +87,13 @@ const router = (EntityService: SessionedEntityService<any, any>) => {
         validate: { params: Validation.EntityIdParams, body: Validation[EntityService.entityType].Entity },
         authorize: { operation: v2Permissions[EntityService.entityType].put },
       }),
-      async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+      async (req: express.Request & { resolvedAgent?: IAgent }, res: express.Response, next: express.NextFunction) => {
         try {
-          const { statusCode, result } = await EntityService.createEntity({
+          // Thanks Typescript :/
+          if (!req.resolvedAgent) {
+            throw new Error('missing agent');
+          }
+          const { statusCode, result } = await EntityService.createEntity(req.resolvedAgent, {
             ...pathParams.accountAndSubscription(req),
             ...body.entity(req, EntityService.entityType),
           });

--- a/api/function-api/src/routes/service/BaseEntityService.ts
+++ b/api/function-api/src/routes/service/BaseEntityService.ts
@@ -12,13 +12,6 @@ export interface IServiceResult {
   result: any;
 }
 
-const rejectPermissionAgent = {
-  checkPermissionSubset: () => {
-    console.log(`XXX Temporary Grant-all on Permissions Until Finalized`);
-    return Promise.resolve();
-  },
-};
-
 export default abstract class BaseEntityService<E extends Model.IEntity, F extends Model.IEntity | E> {
   public abstract readonly entityType: Model.EntityType;
   public readonly dao: Model.IEntityDao<E>;
@@ -34,7 +27,7 @@ export default abstract class BaseEntityService<E extends Model.IEntity, F exten
   };
 
   public abstract sanitizeEntity(entity: Model.IEntity): Model.IEntity;
-  public abstract getFunctionSecuritySpecification(): any;
+  public abstract getFunctionSecuritySpecification(entity: Model.IEntity): any;
 
   public createFunctionSpecification = (entity: Model.IEntity): Function.IFunctionSpecification => {
     // Make a copy of data so the files can be removed.
@@ -62,7 +55,7 @@ export default abstract class BaseEntityService<E extends Model.IEntity, F exten
           ].join('\n'),
         },
       },
-      security: this.getFunctionSecuritySpecification(),
+      security: this.getFunctionSecuritySpecification(entity),
     };
 
     return spec;
@@ -73,20 +66,20 @@ export default abstract class BaseEntityService<E extends Model.IEntity, F exten
     result: await this.dao.getEntity(entity),
   });
 
-  public createEntity = async (entity: Model.IEntity): Promise<IServiceResult> => {
+  public createEntity = async (resolvedAgent: IAgent, entity: Model.IEntity): Promise<IServiceResult> => {
     return operationService.inOperation(
       this.entityType,
       entity,
       { verb: OperationVerbs.creating, type: this.entityType },
       async () => {
         entity = this.sanitizeEntity(entity);
-        await this.createEntityOperation(entity);
+        await this.createEntityOperation(resolvedAgent, entity);
         await this.dao.createEntity(entity);
       }
     );
   };
 
-  public createEntityOperation = async (entity: Model.IEntity) => {
+  public createEntityOperation = async (resolvedAgent: IAgent, entity: Model.IEntity) => {
     const params = {
       accountId: entity.accountId,
       subscriptionId: entity.subscriptionId,
@@ -94,18 +87,14 @@ export default abstract class BaseEntityService<E extends Model.IEntity, F exten
       functionId: entity.id,
     };
 
-    const result = await Function.createFunction(
-      params,
-      this.createFunctionSpecification(entity),
-      rejectPermissionAgent as IAgent
-    );
+    const result = await Function.createFunction(params, this.createFunctionSpecification(entity), resolvedAgent);
 
     if (result.code === 201 && result.buildId) {
       await Function.waitForFunctionBuild(params, result.buildId, 100000);
     }
   };
 
-  public updateEntity = async (entity: Model.IEntity): Promise<IServiceResult> => {
+  public updateEntity = async (resolvedAgent: IAgent, entity: Model.IEntity): Promise<IServiceResult> => {
     return operationService.inOperation(
       this.entityType,
       entity,
@@ -117,7 +106,7 @@ export default abstract class BaseEntityService<E extends Model.IEntity, F exten
         entity = this.sanitizeEntity(entity);
 
         // Delegate to the normal create code to recreate the function.
-        await this.createEntityOperation(entity);
+        await this.createEntityOperation(resolvedAgent, entity);
 
         // Update it.
         await this.dao.updateEntity(entity);

--- a/api/function-api/src/routes/service/ConnectorService.ts
+++ b/api/function-api/src/routes/service/ConnectorService.ts
@@ -70,28 +70,24 @@ class ConnectorService extends SessionedEntityService<Model.IConnector, Model.II
     return entity;
   };
 
-  public getFunctionSecuritySpecification = () => ({
+  public getFunctionSecuritySpecification = (model: Model.IEntity) => ({
     authentication: 'optional',
     functionPermissions: {
       allow: [
         {
           action: Permissions.allStorage,
-          resource: '/account/{{accountId}}/subscription/{{subscriptionId}}/storage/{{boundaryId}/{{functionId}}/',
+          resource: '/account/{{accountId}}/subscription/{{subscriptionId}}/storage/connector/{{functionId}}/',
         },
         {
           action: v2Permissions.putSession,
-          resource: '/account/{{accountId}}/subscription/{{subscriptionId}}/{{boundaryId}/{{functionId}}/session/',
+          resource: '/account/{{accountId}}/subscription/{{subscriptionId}}/connector/{{functionId}}/session/',
         },
         {
           action: v2Permissions.getSession,
-          resource: '/account/{{accountId}}/subscription/{{subscriptionId}}/{{boundaryId}/{{functionId}}/session/',
+          resource: '/account/{{accountId}}/subscription/{{subscriptionId}}/connector/{{functionId}}/session/',
         },
         {
-          action: v2Permissions.identity.get,
-          resource: '/account/{{accountId}}/subscription/{{subscriptionId}}/connector/{{functionId}}/identity/',
-        },
-        {
-          action: v2Permissions.identity.put,
+          action: v2Permissions.identity.all,
           resource: '/account/{{accountId}}/subscription/{{subscriptionId}}/connector/{{functionId}}/identity/',
         },
       ],

--- a/api/function-api/src/routes/service/IdentityService.ts
+++ b/api/function-api/src/routes/service/IdentityService.ts
@@ -1,5 +1,6 @@
 import http_error from 'http-errors';
 
+import { IAgent } from '@5qtrs/account-data';
 import RDS, { Model } from '@5qtrs/db';
 import BaseEntityService from './BaseEntityService';
 
@@ -35,14 +36,14 @@ class IdentityService extends BaseEntityService<Model.IIdentity, Model.IIdentity
     };
   };
 
-  public updateEntity = async (entity: Model.IEntity) => {
+  public updateEntity = async (resolvedAgent: IAgent, entity: Model.IEntity) => {
     return {
       statusCode: 200,
       result: await this.dao.updateEntity(entity),
     };
   };
 
-  public createEntity = async (entity: Model.IEntity) => {
+  public createEntity = async (resolvedAgent: IAgent, entity: Model.IEntity) => {
     return {
       statusCode: 200,
       result: await this.dao.createEntity(entity),

--- a/api/function-api/src/routes/service/InstanceService.ts
+++ b/api/function-api/src/routes/service/InstanceService.ts
@@ -1,5 +1,6 @@
 import http_error from 'http-errors';
 
+import { IAgent } from '@5qtrs/account-data';
 import RDS, { Model } from '@5qtrs/db';
 import BaseEntityService from './BaseEntityService';
 
@@ -35,14 +36,14 @@ class InstanceService extends BaseEntityService<Model.IInstance, Model.IInstance
     };
   };
 
-  public updateEntity = async (entity: Model.IEntity) => {
+  public updateEntity = async (resolvedAgent: IAgent, entity: Model.IEntity) => {
     return {
       statusCode: 200,
       result: await this.dao.updateEntity(entity),
     };
   };
 
-  public createEntity = async (entity: Model.IEntity) => {
+  public createEntity = async (resolvedAgent: IAgent, entity: Model.IEntity) => {
     return {
       statusCode: 200,
       result: await this.dao.createEntity(entity),

--- a/api/function-api/src/routes/service/IntegrationService.ts
+++ b/api/function-api/src/routes/service/IntegrationService.ts
@@ -105,25 +105,44 @@ class IntegrationService extends SessionedEntityService<Model.IIntegration, Mode
     return entity;
   };
 
-  public getFunctionSecuritySpecification = () => ({
-    authentication: 'optional',
-    functionPermissions: {
-      allow: [
-        {
-          action: Permissions.allStorage,
-          resource: '/account/{{accountId}}/subscription/{{subscriptionId}}/storage/{{boundaryId}/{{functionId}}/',
-        },
-        {
-          action: v2Permissions.putSession,
-          resource: '/account/{{accountId}}/subscription/{{subscriptionId}}/{{boundaryId}/{{functionId}}/session/',
-        },
-        {
-          action: v2Permissions.getSession,
-          resource: '/account/{{accountId}}/subscription/{{subscriptionId}}/{{boundaryId}/{{functionId}}/session/',
-        },
-      ],
-    },
-  });
+  public getFunctionSecuritySpecification = (entity: Model.IEntity) => {
+    const integ = entity as Model.IIntegration;
+
+    const permissions = {
+      authentication: 'optional',
+      functionPermissions: {
+        allow: [
+          {
+            action: Permissions.allStorage,
+            resource: '/account/{{accountId}}/subscription/{{subscriptionId}}/storage/integration/{{functionId}}/',
+          },
+          {
+            action: v2Permissions.putSession,
+            resource: '/account/{{accountId}}/subscription/{{subscriptionId}}/integration/{{functionId}}/session/',
+          },
+          {
+            action: v2Permissions.getSession,
+            resource: '/account/{{accountId}}/subscription/{{subscriptionId}}/integration/{{functionId}}/session/',
+          },
+          {
+            action: v2Permissions.instance.all,
+            resource: '/account/{{accountId}}/subscription/{{subscriptionId}}/integration/{{functionId}}/',
+          },
+        ],
+      },
+    };
+
+    // Allow an integration to use connector:execute on it's associated connectors.
+    integ.data.components
+      .filter((component) => component.entityType === Model.EntityType.connector)
+      .forEach((component) => {
+        permissions.functionPermissions.allow.push({
+          action: v2Permissions.connector.execute,
+          resource: `/account/{{accountId}}/subscription/{{subscriptionId}}/connector/${component.entityId}/`,
+        });
+      });
+    return permissions;
+  };
 }
 
 export default IntegrationService;

--- a/api/function-api/test/v1/authz.ts
+++ b/api/function-api/test/v1/authz.ts
@@ -18,6 +18,15 @@ export const permFunctionPutExe = { allow: [reqFunctionPut, reqFunctionExe] };
 export const permFunctionExe = { allow: [reqFunctionExe] };
 export const permFunctionGetExe = { allow: [reqFunctionGet, reqFunctionExe] };
 
+export interface IPermission {
+  action: string;
+  resource: string;
+}
+
+export interface IPermissions {
+  allow: IPermission[];
+}
+
 export const permFunctionPutLimited = (perm: string, acc: IAccount, boundaryId: string) => ({
   allow: [
     {
@@ -31,7 +40,7 @@ export const permFunctionPutLimitedHigher = (perm: string, acc: IAccount) => ({
   allow: [{ action: perm, resource: `/account/${acc.accountId}/` }],
 });
 
-export const getTokenByPerm = async (perm: any) => {
+export const getTokenByPerm = async (perm: IPermissions) => {
   const profile = await FusebitProfile.create();
   const executionProfile = await profile.getPKIExecutionProfile(process.env.FUSE_PROFILE, true, perm);
   return executionProfile.accessToken;

--- a/api/function-api/test/v2/component.permissions.test.ts
+++ b/api/function-api/test/v2/component.permissions.test.ts
@@ -1,0 +1,59 @@
+import { Model } from '@5qtrs/db';
+
+import { Permissions, v2Permissions } from '@5qtrs/constants';
+
+import { ApiRequestMap, cleanupEntities, createPair } from './sdk';
+import * as AuthZ from '../v1/authz';
+
+import { getEnv } from '../v1/setup';
+
+let { account, boundaryId, function1Id, function2Id, function3Id, function4Id, function5Id } = getEnv();
+beforeEach(() => {
+  ({ account, boundaryId, function1Id, function2Id, function3Id, function4Id, function5Id } = getEnv());
+});
+afterAll(async () => {
+  await cleanupEntities(account);
+}, 30000);
+
+describe('Integration to Connector Permissions', () => {
+  test('Integrations have permissions to connector:execute', async () => {
+    const { integrationId, connectorId } = await createPair(account, boundaryId);
+    let response = await ApiRequestMap.integration.dispatch(account, integrationId, 'GET', '/api/token/');
+    expect(response).toBeHttp({ statusCode: 200 });
+    const token = response.data;
+
+    const testSet = [
+      {
+        url: '/api/invalid_key/health',
+        codes: [403, 500],
+      },
+      {
+        url: '/api/invalid_key/token',
+        codes: [403, 500],
+      },
+      {
+        url: '/api/session/invalid_key/token',
+        codes: [403, 500],
+      },
+      {
+        mode: 'DELETE',
+        url: '/api/invalid_key',
+        codes: [403, 400],
+      },
+    ];
+
+    for (const test of testSet) {
+      // Test with no credentials, make sure it's a 403.
+      response = await ApiRequestMap.connector.dispatch(account, connectorId, test.mode || 'GET', test.url, {
+        authz: '',
+      });
+      expect(response).toBeHttp({ statusCode: test.codes[0] });
+
+      // Test with the credentials in the integration, make sure it's... something not a 403.
+      response = await ApiRequestMap.connector.dispatch(account, connectorId, test.mode || 'GET', test.url, {
+        authz: token,
+      });
+      expect(response).toBeHttp({ statusCode: test.codes[1] });
+    }
+  }, 180000);
+});

--- a/api/function-api/test/v2/connector.permissions.test.ts
+++ b/api/function-api/test/v2/connector.permissions.test.ts
@@ -1,0 +1,20 @@
+import { Model } from '@5qtrs/db';
+
+import { Permissions, v2Permissions } from '@5qtrs/constants';
+
+import { ApiRequestMap, cleanupEntities, createPair } from './sdk';
+import * as AuthZ from '../v1/authz';
+
+import { getEnv } from '../v1/setup';
+
+let { account, boundaryId, function1Id, function2Id, function3Id, function4Id, function5Id } = getEnv();
+beforeEach(() => {
+  ({ account, boundaryId, function1Id, function2Id, function3Id, function4Id, function5Id } = getEnv());
+});
+afterAll(async () => {
+  await cleanupEntities(account);
+}, 30000);
+
+describe('Integration Permission', () => {
+  test('Integrations have permissions to connector:execute', async () => {}, 180000);
+});

--- a/api/function-api/test/v2/integration.permissions.test.ts
+++ b/api/function-api/test/v2/integration.permissions.test.ts
@@ -1,0 +1,160 @@
+import { Model } from '@5qtrs/db';
+
+import { Permissions, v2Permissions } from '@5qtrs/constants';
+
+import { ApiRequestMap, cleanupEntities, createPair } from './sdk';
+import * as AuthZ from '../v1/authz';
+
+import { getEnv } from '../v1/setup';
+// Without this, the test doesn't exit because keyStore is still running.
+import { keyStore } from '../v1/function.utils';
+
+import { checkAuthorization } from '../../src/routes/functions';
+
+let { account, boundaryId, function1Id, function2Id, function3Id, function4Id, function5Id } = getEnv();
+beforeEach(() => {
+  ({ account, boundaryId, function1Id, function2Id, function3Id, function4Id, function5Id } = getEnv());
+});
+
+afterAll(async () => {
+  await cleanupEntities(account);
+}, 30000);
+
+const getSimpleIntegration = (): any => ({
+  id: `${boundaryId}-integ`,
+  data: {
+    components: [],
+    componentTags: {},
+    configuration: {},
+
+    handler: './integration',
+    files: {
+      ['integration.js']: '',
+    },
+  },
+});
+
+describe('Integration Permissions', () => {
+  test('Force function.utils to clean up', () => {
+    // Without this, the function.utils import gets pruned
+    let ks = keyStore;
+    ks = ks;
+  });
+
+  test('Does the integration have the correct set of permissions', async () => {
+    const { integrationId, connectorId } = await createPair(account, boundaryId);
+    const response = await ApiRequestMap.integration.dispatch(account, integrationId, 'GET', '/api/token/');
+    expect(response).toBeHttp({ statusCode: 200 });
+    const token = response.data;
+
+    const basePath = `/account/${account.accountId}/subscription/${account.subscriptionId}`;
+    const integWart = `/integration/${integrationId}`;
+    const allowedTable = [
+      { action: Permissions.allStorage, resource: `${basePath}/storage${integWart}/some/path` },
+      {
+        action: v2Permissions.putSession,
+        resource: `${basePath}${integWart}/session/123e4567-e89b-12d3-a456-426614174000`,
+      },
+      {
+        action: v2Permissions.getSession,
+        resource: `${basePath}${integWart}/session/123e4567-e89b-12d3-a456-426614174000`,
+      },
+      {
+        action: v2Permissions.connector.execute,
+        resource: `${basePath}/connector/${connectorId}/`,
+      },
+    ];
+
+    for (const operation of allowedTable) {
+      await expect(
+        checkAuthorization(account.accountId, token, 'required', undefined, operation)
+      ).resolves.toMatchObject({});
+    }
+  }, 180000);
+
+  test('Low-privledge user cannot create an integration', async () => {
+    const integEntity = getSimpleIntegration();
+
+    // Create a token that has permissions to write integrations but nothing else.
+    const basicPutToken = await AuthZ.getTokenByPerm({
+      allow: [
+        { action: v2Permissions.integration.put, resource: '/' },
+        { action: v2Permissions.integration.get, resource: '/' },
+      ],
+    });
+
+    // Test with basic permissions, but not enough
+    const response = await ApiRequestMap.integration.postAndWait(account, integEntity, undefined, {
+      authz: basicPutToken,
+    });
+    expect(response).toBeHttp({ statusCode: 400 });
+  }, 180000);
+
+  //
+  test('Integration without connectors does not require connector:execute permissions', async () => {
+    const integEntity = getSimpleIntegration();
+
+    const simplePutToken = await AuthZ.getTokenByPerm({
+      allow: [
+        { action: v2Permissions.integration.put, resource: '/' },
+        { action: v2Permissions.integration.get, resource: '/' },
+        { action: Permissions.allStorage, resource: '/' },
+        { action: v2Permissions.putSession, resource: '/' },
+        { action: v2Permissions.getSession, resource: '/' },
+        { action: v2Permissions.instance.all, resource: '/' },
+      ],
+    });
+
+    // Test with enough permissions, but no execute - succeeds because no connectors
+    const response = await ApiRequestMap.integration.postAndWait(account, integEntity, undefined, {
+      authz: simplePutToken,
+    });
+    expect(response).toBeHttp({ statusCode: 200 });
+  }, 180000);
+
+  test('Integration with connectors requires execute permissions', async () => {
+    const integEntity = getSimpleIntegration();
+
+    // Add a connector to the entity
+    integEntity.data.components.push({
+      name: 'con',
+      entityType: Model.EntityType.connector,
+      entityId: `${boundaryId}-conn`,
+      provider: '@fusebit-int/oauth-provider',
+      dependsOn: [],
+    });
+    integEntity.id = `${boundaryId}-integ-2`;
+
+    const basePerms = [
+      { action: v2Permissions.integration.put, resource: '/' },
+      { action: v2Permissions.integration.get, resource: '/' },
+      { action: Permissions.allStorage, resource: '/' },
+      { action: v2Permissions.putSession, resource: '/' },
+      { action: v2Permissions.getSession, resource: '/' },
+      { action: v2Permissions.instance.all, resource: '/' },
+    ];
+    const simplePutToken = await AuthZ.getTokenByPerm({ allow: basePerms });
+
+    const executeToken = await AuthZ.getTokenByPerm({
+      allow: [...basePerms, { action: v2Permissions.connector.execute, resource: '/' }],
+    });
+
+    // Test with no execute fails
+    let response = await ApiRequestMap.integration.postAndWait(account, integEntity, undefined, {
+      authz: simplePutToken,
+    });
+    expect(response).toBeHttp({ statusCode: 400 });
+
+    // Test with execute succeeds
+    response = await ApiRequestMap.integration.postAndWait(account, integEntity, undefined, { authz: executeToken });
+    expect(response).toBeHttp({ statusCode: 200 });
+  }, 180000);
+
+  test('Create an entity without any authz fails', async () => {
+    const integEntity = getSimpleIntegration();
+
+    // Test with no permissions
+    const response = await ApiRequestMap.integration.post(account, integEntity, { authz: '' });
+    expect(response).toBeHttp({ statusCode: 403 });
+  }, 180000);
+});

--- a/api/function-api/test/v2/permissions.test.ts
+++ b/api/function-api/test/v2/permissions.test.ts
@@ -1,6 +1,9 @@
 import { Model } from '@5qtrs/db';
 
-import { ApiRequestMap } from './sdk';
+import { Permissions, v2Permissions } from '@5qtrs/constants';
+
+import { ApiRequestMap, cleanupEntities, createPair } from './sdk';
+import * as AuthZ from '../v1/authz';
 
 import { getEnv } from '../v1/setup';
 
@@ -8,6 +11,9 @@ let { account, boundaryId, function1Id, function2Id, function3Id, function4Id, f
 beforeEach(() => {
   ({ account, boundaryId, function1Id, function2Id, function3Id, function4Id, function5Id } = getEnv());
 });
+afterAll(async () => {
+  await cleanupEntities(account);
+}, 30000);
 
 const crudPermissions = async (entityType: Model.EntityType, authz: string) => {
   await expect(ApiRequestMap[entityType].get(account, 'inv', { authz })).resolves.toBeHttp({ statusCode: 403 });

--- a/api/function-api/test/v2/sdk.ts
+++ b/api/function-api/test/v2/sdk.ts
@@ -227,7 +227,7 @@ export const ApiRequestMap: { [key: string]: any } = {
       waitOptions: IWaitForCompletionParams = DefaultWaitForCompletionParams,
       options?: IRequestOptions
     ) => {
-      const op = await ApiRequestMap.connector.post(account, body);
+      const op = await ApiRequestMap.connector.post(account, body, options);
       expect(op).toBeHttp({ statusCode: 202 });
       validateOperation(account, op, Model.EntityType.connector);
 
@@ -459,7 +459,7 @@ export const ApiRequestMap: { [key: string]: any } = {
       waitOptions: IWaitForCompletionParams = DefaultWaitForCompletionParams,
       options?: IRequestOptions
     ) => {
-      const op = await ApiRequestMap.integration.post(account, body);
+      const op = await ApiRequestMap.integration.post(account, body, options);
       expect(op).toBeHttp({ statusCode: 202 });
       validateOperation(account, op, Model.EntityType.integration);
 
@@ -770,6 +770,7 @@ export const createPair = async (
           'const integration = new Integration();',
           'const router = integration.router;',
           "router.get('/api/', async (ctx) => { });",
+          "router.get('/api/token/', async (ctx) => { ctx.body = ctx.state.params.functionAccessToken; });",
           'module.exports = integration;',
         ].join('\n'),
       },

--- a/lib/constants/src/permissions.ts
+++ b/lib/constants/src/permissions.ts
@@ -50,20 +50,29 @@ export enum Permissions {
   putRegistry = 'registry:put',
 }
 
-const makePermissionSet = (prefix: string) => ({
-  [prefix]: {
-    get: `${prefix}:get`,
-    put: `${prefix}:put`,
-    delete: `${prefix}:delete`,
-    putTag: `${prefix}:put-tag`,
-  },
+interface IPermissionSet {
+  get: string;
+  put: string;
+  delete: string;
+  putTag: string;
+  execute: string;
+  all: string;
+}
+
+const makePermissionSet = (prefix: string): IPermissionSet => ({
+  get: `${prefix}:get`,
+  put: `${prefix}:put`,
+  delete: `${prefix}:delete`,
+  putTag: `${prefix}:put-tag`,
+  execute: `${prefix}:execute`,
+  all: `${prefix}:*`,
 });
 
-export const v2Permissions: Record<any, any> = {
-  ...makePermissionSet('integration'),
-  ...makePermissionSet('instance'),
-  ...makePermissionSet('connector'),
-  ...makePermissionSet('identity'),
+export const v2Permissions: any = {
+  integration: makePermissionSet('integration'),
+  instance: makePermissionSet('instance'),
+  connector: makePermissionSet('connector'),
+  identity: makePermissionSet('identity'),
   putOperation: 'operation:put',
   postSession: 'session:post',
   putSession: 'session:put',

--- a/lib/pkg/oauth/oauth-connector/src/OAuthManager.ts
+++ b/lib/pkg/oauth/oauth-connector/src/OAuthManager.ts
@@ -36,43 +36,54 @@ router.on('startup', async ({ mgr, cfg, router: rtr }: Connector.Types.IOnStartu
 });
 
 // Internal Endpoints
-router.get('/api/:lookupKey/health', async (ctx: Connector.Types.Context) => {
-  try {
+router.get(
+  '/api/:lookupKey/health',
+  connector.middleware.authorizeUser('connector:execute'),
+  async (ctx: Connector.Types.Context) => {
     if (!(await engine.ensureAccessToken(ctx, ctx.params.lookupKey))) {
       ctx.throw(404);
     }
     ctx.status = 200;
-  } catch (error) {
-    ctx.status = 500;
-    ctx.message = error.message;
   }
-});
+);
 
-router.get('/api/session/:lookupKey/token', async (ctx: Connector.Types.Context) => {
-  try {
-    ctx.body = await engine.ensureAccessToken(ctx, ctx.params.lookupKey, false);
-  } catch (error) {
-    ctx.throw(500, error.message);
+router.get(
+  '/api/session/:lookupKey/token',
+  connector.middleware.authorizeUser('connector:execute'),
+  async (ctx: Connector.Types.Context) => {
+    try {
+      ctx.body = await engine.ensureAccessToken(ctx, ctx.params.lookupKey, false);
+    } catch (error) {
+      ctx.throw(500, error.message);
+    }
+    if (!ctx.body) {
+      ctx.throw(404);
+    }
   }
-  if (!ctx.body) {
-    ctx.throw(404);
-  }
-});
+);
 
-router.get('/api/:lookupKey/token', async (ctx: Connector.Types.Context) => {
-  try {
-    ctx.body = await engine.ensureAccessToken(ctx, ctx.params.lookupKey);
-  } catch (error) {
-    ctx.throw(500, error.message);
+router.get(
+  '/api/:lookupKey/token',
+  connector.middleware.authorizeUser('connector:execute'),
+  async (ctx: Connector.Types.Context) => {
+    try {
+      ctx.body = await engine.ensureAccessToken(ctx, ctx.params.lookupKey);
+    } catch (error) {
+      ctx.throw(500, error.message);
+    }
+    if (!ctx.body) {
+      ctx.throw(404);
+    }
   }
-  if (!ctx.body) {
-    ctx.throw(404);
-  }
-});
+);
 
-router.delete('/api/:lookupKey', async (ctx: Connector.Types.Context) => {
-  ctx.body = await engine.deleteUser(ctx, ctx.params.lookupKey);
-});
+router.delete(
+  '/api/:lookupKey',
+  connector.middleware.authorizeUser('connector:execute'),
+  async (ctx: Connector.Types.Context) => {
+    ctx.body = await engine.deleteUser(ctx, ctx.params.lookupKey);
+  }
+);
 
 // OAuth Flow Endpoints
 router.get('/api/authorize', async (ctx: Connector.Types.Context) => {


### PR DESCRIPTION
Right now there's no required authz on connector endpoints that return a token from a session or an identity.

Add a connector:execute permission to the v2Permissions.

Populate the permissions in IntegrationSession.ts with the connector:execute permissions for the connectors that integration connects with.

Validate that the user performing the integration creation/update has those connector:execute permissions on their user - this will probably require plumbing in the authorized user from the schema into the session object and then down to the function.ts createFunction call.

Require the connector:execute permission via the middleware in the connector packages for OAuth, Slack, etc.