### PR TITLE
[6]. 333. Hide connector secrets from the configuration screen

### DIFF
--- a/lib/pkg/oauth/oauth-connector/package.json
+++ b/lib/pkg/oauth/oauth-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fusebit-int/oauth-connector",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "main": "libc/index.js",
   "files": ["libc/*.js", "libc/*.d.ts"],

--- a/lib/pkg/oauth/oauth-connector/src/configure/uischema.json
+++ b/lib/pkg/oauth/oauth-connector/src/configure/uischema.json
@@ -15,7 +15,10 @@
     },
     {
       "type": "Control",
-      "scope": "#/properties/clientSecret"
+      "scope": "#/properties/clientSecret",
+      "options": {
+        "format": "password"
+      }
     },
     {
       "type": "Control",

--- a/lib/pkg/slack/slack-connector/package.json
+++ b/lib/pkg/slack/slack-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fusebit-int/slack-connector",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "main": "libc/index.js",
   "files": ["libc/**/*.js", "libc/**/*.d.ts", "libc/**/*.json"],

--- a/lib/pkg/slack/slack-connector/src/configure/schema.json
+++ b/lib/pkg/slack/slack-connector/src/configure/schema.json
@@ -1,46 +1,46 @@
 {
   "type": "object",
   "properties": {
-    "settings": {
-      "title": "Settings",
-      "type": "object",
-      "properties": {
-        "scope": {
-          "title": "Scope",
-          "description": "Comma separated scopes to request from your Slack app",
-          "type": "string"
-        },
-        "clientId": {
-          "title": "Client ID",
-          "description": "The client ID from your Slack app",
-          "type": "string"
-        },
-        "clientSecret": {
-          "title": "Client Secret",
-          "type": "string",
-          "description": "The client Secret from your Slack app"
-        }
-      },
-      "required": ["scope", "clientId", "clientSecret"]
+    "scope": {
+      "title": "Scope",
+      "description": "Comma separated scopes to request from your Slack app",
+      "type": "string"
     },
-    "advanced": {
-      "properties": {
-        "refreshErrorLimit": {
-          "type": "integer"
-        },
-        "refreshInitialBackoff": {
-          "type": "integer"
-        },
-        "refreshWaitCountLimit": {
-          "type": "integer"
-        },
-        "refreshBackoffIncrement": {
-          "type": "integer"
-        },
-        "accessTokenExpirationBuffer": {
-          "type": "integer"
-        }
-      }
+    "tokenUrl": {
+      "title": "OAuth Token URL",
+      "description": "The authentication URL to use when exchanging tokens, as per the OAuth protocol",
+      "type": "string"
+    },
+    "authorizationUrl": {
+      "title": "OAuth Authorization URL",
+      "description": "The authorization URL to use when generating authorization codes, as per the OAuth protocol",
+      "type": "string"
+    },
+    "clientId": {
+      "title": "Client ID",
+      "description": "The Client ID from your Slack app",
+      "type": "string"
+    },
+    "clientSecret": {
+      "title": "Client Secret",
+      "type": "string",
+      "description": "The Client Secret from your Slack app"
+    },
+    "refreshErrorLimit": {
+      "type": "integer"
+    },
+    "refreshInitialBackoff": {
+      "type": "integer"
+    },
+    "refreshWaitCountLimit": {
+      "type": "integer"
+    },
+    "refreshBackoffIncrement": {
+      "type": "integer"
+    },
+    "accessTokenExpirationBuffer": {
+      "type": "integer"
     }
-  }
+  },
+  "required": ["scope", "clientId", "clientSecret"]
 }

--- a/lib/pkg/slack/slack-connector/src/configure/uischema.json
+++ b/lib/pkg/slack/slack-connector/src/configure/uischema.json
@@ -7,15 +7,18 @@
       "elements": [
         {
           "type": "Control",
-          "scope": "#/properties/settings/properties/scope"
+          "scope": "#/properties/scope"
         },
         {
           "type": "Control",
-          "scope": "#/properties/settings/properties/clientId"
+          "scope": "#/properties/clientId"
         },
         {
           "type": "Control",
-          "scope": "#/properties/settings/properties/clientSecret"
+          "scope": "#/properties/clientSecret",
+          "options": {
+            "format": "password"
+          }
         }
       ]
     },
@@ -25,23 +28,31 @@
       "elements": [
         {
           "type": "Control",
-          "scope": "#/properties/advanced/properties/refreshErrorLimit"
+          "scope": "#/properties/tokenUrl"
         },
         {
           "type": "Control",
-          "scope": "#/properties/advanced/properties/refreshInitialBackoff"
+          "scope": "#/properties/authorizationUrl"
         },
         {
           "type": "Control",
-          "scope": "#/properties/advanced/properties/refreshWaitCountLimit"
+          "scope": "#/properties/refreshErrorLimit"
         },
         {
           "type": "Control",
-          "scope": "#/properties/advanced/properties/refreshBackoffIncrement"
+          "scope": "#/properties/refreshInitialBackoff"
         },
         {
           "type": "Control",
-          "scope": "#/properties/advanced/properties/accessTokenExpirationBuffer"
+          "scope": "#/properties/refreshWaitCountLimit"
+        },
+        {
+          "type": "Control",
+          "scope": "#/properties/refreshBackoffIncrement"
+        },
+        {
+          "type": "Control",
+          "scope": "#/properties/accessTokenExpirationBuffer"
         }
       ]
     }

--- a/lib/pkg/slack/slack-connector/src/index.ts
+++ b/lib/pkg/slack/slack-connector/src/index.ts
@@ -18,7 +18,7 @@ router.get(
   connector.middleware.authorizeUser('connector:put'),
   async (ctx: Connector.Types.Context) => {
     ctx.body = {
-      data: { tokenUrl: TOKEN_URL, authorizationUrl: AUTHORIZATION_URL, ...ctx.state.manager.config.configuration },
+      data: ctx.state.manager.config.configuration,
       schema,
       uischema,
     };

--- a/site/catalog/feed_integration/slack-hello-world/connector/fusebit.json
+++ b/site/catalog/feed_integration/slack-hello-world/connector/fusebit.json
@@ -1,7 +1,7 @@
 {
   "id": "<%this.id%>",
   "tags": {},
-  "handler": "@fusebit-int/oauth-connector",
+  "handler": "@fusebit-int/slack-connector",
   "configuration": {
     "scope": "chat:write",
     "tokenUrl": "<%global.consts.endpoint%>/v2/account/<%global.consts.accountId%>/subscription/<%global.consts.subscriptionId%>/connector/<%this.id%>/proxy/slack/oauth/token",


### PR DESCRIPTION
Two changes of note here:
  1. Change the jsonforms schema so that client secret fields are hidden
     by default.
  2. Change the catalog feed over to use slack-connector instead of
     oauth-connector.