### PR TITLE
Silence ResourceConflictException exceptions on module and function builder lambdas

### DIFF
--- a/lib/server/function-lambda/src/create_function_worker.js
+++ b/lib/server/function-lambda/src/create_function_worker.js
@@ -921,7 +921,9 @@ function create_function_builder(options, cb) {
     },
     Role: process.env.LAMBDA_BUILDER_ROLE,
   };
-  return Common.Lambda.createFunction(create_builder_params, (e, d) => (e ? cb(e) : cb()));
+  return Common.Lambda.createFunction(create_builder_params, (e) =>
+    e && e.code !== 'ResourceConflictException' ? cb(e) : cb()
+  );
 }
 
 function create_module_builder(name, ctx, cb) {
@@ -937,7 +939,9 @@ function create_module_builder(name, ctx, cb) {
     },
     Role: process.env.LAMBDA_MODULE_BUILDER_ROLE,
   };
-  return Common.Lambda.createFunction(create_builder_params, (e, d) => (e ? cb(e) : cb()));
+  return Common.Lambda.createFunction(create_builder_params, (e) =>
+    e && e.code !== 'ResourceConflictException' ? cb(e) : cb()
+  );
 }
 
 async function create_npmrc(ctx) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.22.3",
+  "version": "1.22.4",
   "private": true,
   "org": "5qtrs",
   "engines": {


### PR DESCRIPTION
Simultaneous creation of two functions that use the same new module can cause a 409 to be returned to the client. Silently eat this error, as the function already existing is good enough to work with.