### PR TITLE
NFC: Skip Cron Tests For Now

### DIFF
--- a/api/function-api/test/v1/cron.test.ts
+++ b/api/function-api/test/v1/cron.test.ts
@@ -9,7 +9,7 @@ beforeEach(() => {
   ({ account, boundaryId, function1Id, function2Id, function3Id, function4Id, function5Id } = getEnv());
 });
 
-describe('cron', () => {
+describe.skip('cron', () => {
   test(
     'cron executes on schedule',
     async () => {


### PR DESCRIPTION
Cron is causing test systems too many problems so that we won't be pinged constantly, probably wise to skip for now.