### PR TITLE
npm test job, only notify on failure

### DIFF
--- a/.github/workflows/test_cli_npm7.yml
+++ b/.github/workflows/test_cli_npm7.yml
@@ -25,15 +25,6 @@ jobs:
           npm i -g @fusebit/cli
 
           fuse
-      - name: Notify slack success
-        if: success()
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: pr-review
-          status: SUCCESS
-          color: good
       - name: Notify slack fail
         if: failure()
         env:


### PR DESCRIPTION
This PR allows notifying npm test job only when it fails.