### PR TITLE
Logging improvements

### DIFF
--- a/api/function-api/src/routes/functions.ts
+++ b/api/function-api/src/routes/functions.ts
@@ -41,6 +41,7 @@ interface IFunctionSpecification {
     memorySize?: number;
     timeout?: number;
     staticIp?: boolean;
+    persistLogs?: boolean;
   };
   computeSerialized?: string;
   schedule?: {

--- a/api/function-api/src/routes/middleware/analytics.js
+++ b/api/function-api/src/routes/middleware/analytics.js
@@ -58,10 +58,20 @@ exports.enterHandler = (modality) => {
         subscriptionId: reqProps.params.subscriptionId,
         boundaryId: reqProps.params.boundaryId,
         functionId: reqProps.params.functionId,
+        sessionId: reqProps.params.sessionId,
+        identityId: reqProps.params.identityId,
+        installId: reqProps.params.installId,
         deploymentKey: process.env.DEPLOYMENT_KEY,
         mode: 'request',
         modality: req.analyticsModality || modality,
       };
+      if (req.entityType && reqProps.params.entityId) {
+        fusebit[`${req.entityType}Id`] = reqProps.params.entityId;
+        if (fusebit.modality === 'execution') {
+          fusebit.boundaryId = req.entityType;
+          fusebit.functionId = reqProps.params.entityId;
+        }
+      }
 
       // Create a copy of params to avoid accidental side effects.
       reqProps.params = {
@@ -93,6 +103,11 @@ exports.enterHandler = (modality) => {
 
 exports.setModality = (modality) => (req, res, next) => {
   req.analyticsModality = modality;
+  return next();
+};
+
+exports.setEntityType = (entityType) => (req, res, next) => {
+  req.entityType = entityType;
   return next();
 };
 

--- a/api/function-api/src/routes/schema/common/index.ts
+++ b/api/function-api/src/routes/schema/common/index.ts
@@ -13,7 +13,12 @@ const router = (EntityService: SessionedEntityService<any, any>) => {
   r.use(analytics.setModality(analytics.Modes.Administration));
   r.use('/:entityId/session', componentSessionRouter(EntityService));
   r.use('/:entityId/tag', componentTagRouter(EntityService));
-  r.use('/:entityId', componentCrudRouter(EntityService), dispatchRouter(EntityService));
+  r.use(
+    '/:entityId',
+    componentCrudRouter(EntityService),
+    analytics.setModality(analytics.Modes.Execution),
+    dispatchRouter(EntityService)
+  );
   r.use('/', componentRootRouter(EntityService));
 
   return r;

--- a/api/function-api/src/routes/schema/index.ts
+++ b/api/function-api/src/routes/schema/index.ts
@@ -29,6 +29,7 @@ router.use('/connector/:entityId/proxy/:proxyType/oauth', createProxyRouter(subs
 
 router.use(
   '/connector',
+  analytics.setEntityType(Model.EntityType.connector),
   common(connectorService),
   connectorFanOut(connectorService, integrationService, installService),
   SubcomponentRouter(identityService, ['entityId', 'identityId'], Model.EntityType.connector)
@@ -36,6 +37,7 @@ router.use(
 
 router.use(
   '/integration',
+  analytics.setEntityType(Model.EntityType.integration),
   common(integrationService),
   SubcomponentRouter(installService, ['entityId', 'installId'], Model.EntityType.integration)
 );

--- a/api/function-api/src/routes/service/BaseEntityService.ts
+++ b/api/function-api/src/routes/service/BaseEntityService.ts
@@ -116,6 +116,9 @@ export default abstract class BaseEntityService<E extends Model.IEntity, F exten
           ].join('\n'),
         },
       },
+      compute: {
+        persistLogs: true,
+      },
       security: this.getFunctionSecuritySpecification(entity),
     };
 

--- a/docs/release-notes/fusebit-http-api.md
+++ b/docs/release-notes/fusebit-http-api.md
@@ -17,6 +17,13 @@ All public releases of the Fusebit HTTP API are documented here, including notab
 <!-- 1. TOC
 {:toc} -->
 
+## Version 1.28.2
+
+_Released 11/4/21_
+
+- **Enhancement.** Enable persistent capture of stdout/err of connectors and integrations by default.
+- **Enhancement.** Add more metadata to CloudWatch events related to integrations and connectors.
+
 ## Version 1.28.1
 
 _Released 11/2/21_

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.28.1",
+  "version": "1.28.2",
   "private": true,
   "org": "5qtrs",
   "engines": {


### PR DESCRIPTION
1. Set modality of CloudWatch events to `execute` when the `/api` routes on integrations or connectors are invoked. Before the modality was set to `administration`. 
2. Add `connectorId`, `integrationId`, `installId`, `identityId`, and `sessionId` to the `fusebit.` property of CloudWatch events on relevant invocations. 
3. Enable `persistLogs: true` for integrations and connectors. 