### PR TITLE
Fuse CLI support for custom authorization account ID

### DIFF
--- a/cli/fusebit-cli/package.json
+++ b/cli/fusebit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/fusebit-cli",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "",
   "main": "libc/index.js",
   "bin": {
@@ -9,7 +9,11 @@
   "license": "MIT",
   "author": "https://fusebit.io",
   "packageAs": "@fusebit/cli",
-  "packageAssets": ["template", "README.md", "LICENSE"],
+  "packageAssets": [
+    "template",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc -b",
     "test": "jest --colors",

--- a/cli/fusebit-cli/src/FusebitCli.ts
+++ b/cli/fusebit-cli/src/FusebitCli.ts
@@ -1,4 +1,4 @@
-import { Command, ICommand, IExecuteInput, ArgType } from '@5qtrs/cli';
+import { Command, ICommand, IExecuteInput, ArgType, MessageKind, Message } from '@5qtrs/cli';
 import { Text } from '@5qtrs/text';
 import {
   ClientCommand,
@@ -81,6 +81,23 @@ export class FusebitCli extends Command {
     }
     if (!skipInit) {
       await InitCommand.createDefaultProfileIfNoneExists(input);
+    }
+    if (process.env.FUSEBIT_AUTHORIZATION_ACCOUNT_ID || process.env.FUSEBIT_ACCOUNT_ID) {
+      const message = await Message.create({
+        kind: MessageKind.warning,
+        header: 'Profile Overrides',
+        message: Text.create(
+          'The command will execute with the following profile overrides: ',
+          Text.eol(),
+          Text.eol(),
+          'Authorization account Id: ',
+          Text.bold(process.env.FUSEBIT_AUTHORIZATION_ACCOUNT_ID || 'N/A'),
+          Text.eol(),
+          'Account Id: ',
+          Text.bold(process.env.FUSEBIT_ACCOUNT_ID || 'N/A')
+        ),
+      });
+      message.write(input.io);
     }
     return super.onSubCommandExecuting(command, input);
   }

--- a/cli/fusebit-cli/src/commands/VersionCommand.ts
+++ b/cli/fusebit-cli/src/commands/VersionCommand.ts
@@ -36,11 +36,10 @@ export class VersionCommand extends Command {
 
   protected async onExecute(input: IExecuteInput): Promise<number> {
     const excuteService = await ExecuteService.create(input);
-    const versionService = await VersionService.create(input);
 
     await excuteService.newLine();
 
-    const version = await versionService.getVersion();
+    const version = VersionService.getVersion();
 
     const output = input.options.output;
     if (output === 'json') {

--- a/cli/fusebit-cli/src/commands/connector/ConnectorCommand.ts
+++ b/cli/fusebit-cli/src/commands/connector/ConnectorCommand.ts
@@ -28,6 +28,11 @@ const command: ICommand = {
       description: 'The name of the profile to use when executing the command',
       defaultText: 'default profile',
     },
+    {
+      name: 'subscription',
+      description: 'The subscription id to use when executing the command',
+      defaultText: 'profile value',
+    },
   ],
 };
 

--- a/cli/fusebit-cli/src/commands/npm/Npm.ts
+++ b/cli/fusebit-cli/src/commands/npm/Npm.ts
@@ -1,5 +1,3 @@
-import { request } from '@5qtrs/request';
-
 import { IFusebitExecutionProfile } from '@5qtrs/fusebit-profile-sdk';
 
 import { getProtoUrl, IRegistries } from './registry/Registry';

--- a/cli/fusebit-cli/src/commands/npm/NpmSearchCommand.ts
+++ b/cli/fusebit-cli/src/commands/npm/NpmSearchCommand.ts
@@ -1,7 +1,6 @@
 const { spawn } = require('child_process');
 
 import { ArgType, Command, ICommand, IExecuteInput } from '@5qtrs/cli';
-import { request } from '@5qtrs/request';
 
 import { ProfileService } from '../../services/ProfileService';
 

--- a/cli/fusebit-cli/src/commands/npm/registry/Registry.ts
+++ b/cli/fusebit-cli/src/commands/npm/registry/Registry.ts
@@ -1,6 +1,6 @@
 import { request } from '@5qtrs/request';
 
-import { IText, Text } from '@5qtrs/text';
+import { Text } from '@5qtrs/text';
 import { ExecuteService } from '../../../services/ExecuteService';
 
 import { IFusebitExecutionProfile } from '@5qtrs/fusebit-profile-sdk';
@@ -15,10 +15,13 @@ interface IRegistry {
 }
 
 async function getRegistry(profile: IFusebitExecutionProfile): Promise<IRegistries> {
+  const headers = { Authorization: `bearer ${profile.accessToken}` };
+  ExecuteService.addCommonHeaders(headers);
+
   const response: any = await request({
     method: 'GET',
     url: `${profile.baseUrl}/v1/account/${profile.account}/registry/default/`,
-    headers: { Authorization: `bearer ${profile.accessToken}` },
+    headers,
   });
 
   return { default: response.data as IRegistry };
@@ -29,10 +32,12 @@ async function putRegistry(
   executeService: ExecuteService,
   scopes: string[]
 ): Promise<IRegistries> {
+  const headers = { Authorization: `bearer ${profile.accessToken}` };
+  ExecuteService.addCommonHeaders(headers);
   const response: any = await request({
     method: 'PUT',
     url: `${profile.baseUrl}/v1/account/${profile.account}/registry/default/`,
-    headers: { Authorization: `bearer ${profile.accessToken}` },
+    headers,
     data: { scopes },
   });
 

--- a/cli/fusebit-cli/src/services/BaseComponentService.ts
+++ b/cli/fusebit-cli/src/services/BaseComponentService.ts
@@ -69,12 +69,12 @@ export abstract class BaseComponentService<IComponentType extends IBaseComponent
 
   public async createNewSpec(): Promise<IComponentType> {
     const profile = await this.profileService.getExecutionProfile(['account', 'subscription']);
+    const headers = { Authorization: `bearer ${profile.accessToken}` };
+    ExecuteService.addCommonHeaders(headers);
     const response = await request({
       method: 'GET',
       url: this.getUrl(profile, '?defaults=true'),
-      headers: {
-        Authorization: `Bearer ${profile.accessToken}`,
-      },
+      headers,
     });
 
     return response.data.items[0].template;
@@ -239,12 +239,12 @@ export abstract class BaseComponentService<IComponentType extends IBaseComponent
   }
 
   public async getEntity(profile: IFusebitExecutionProfile, entityId: string): Promise<IHttpResponse> {
+    const headers = { Authorization: `bearer ${profile.accessToken}` };
+    ExecuteService.addCommonHeaders(headers);
     return request({
       method: 'GET',
       url: this.getUrl(profile, entityId),
-      headers: {
-        Authorization: `Bearer ${profile.accessToken}`,
-      },
+      headers,
     });
   }
 

--- a/cli/fusebit-cli/src/services/EntityService.ts
+++ b/cli/fusebit-cli/src/services/EntityService.ts
@@ -1,5 +1,3 @@
-import { request, IHttpResponse } from '@5qtrs/request';
-
 import { Text } from '@5qtrs/text';
 import { IFusebitExecutionProfile } from '@5qtrs/fusebit-profile-sdk';
 import { IExecuteInput, Confirm, Message } from '@5qtrs/cli';

--- a/cli/fusebit-cli/src/services/LogService.ts
+++ b/cli/fusebit-cli/src/services/LogService.ts
@@ -1,10 +1,9 @@
 import { Text, IText } from '@5qtrs/text';
 import { IFusebitExecutionProfile } from '@5qtrs/fusebit-profile-sdk';
-import { IExecuteInput, Message } from '@5qtrs/cli';
+import { IExecuteInput } from '@5qtrs/cli';
 import { ProfileService } from './ProfileService';
 import { ExecuteService } from './ExecuteService';
 import { IColumnConstraint, Table } from '@5qtrs/table';
-import { start } from 'repl';
 
 const queryTimeout = 2 * 60; // Max two minutes
 

--- a/cli/fusebit-cli/src/services/ProfileService.ts
+++ b/cli/fusebit-cli/src/services/ProfileService.ts
@@ -413,7 +413,7 @@ export class ProfileService {
     return {
       accessToken: accessToken as string,
       baseUrl: profile.baseUrl,
-      account: profile.account,
+      account: process.env.FUSEBIT_ACCOUNT_ID || profile.account,
       subscription: profile.subscription || undefined,
       boundary: profile.boundary || undefined,
       function: profile.function || undefined,

--- a/cli/fusebit-cli/src/services/StorageService.ts
+++ b/cli/fusebit-cli/src/services/StorageService.ts
@@ -1,5 +1,3 @@
-import { request, IHttpResponse } from '@5qtrs/request';
-
 import { Text } from '@5qtrs/text';
 import { IFusebitExecutionProfile } from '@5qtrs/fusebit-profile-sdk';
 import { IExecuteInput, Confirm } from '@5qtrs/cli';

--- a/cli/fusebit-cli/src/services/VersionService.ts
+++ b/cli/fusebit-cli/src/services/VersionService.ts
@@ -1,6 +1,5 @@
-import { IExecuteInput, MessageKind, Message } from '@5qtrs/cli';
 import { join } from 'path';
-import { readFile } from '@5qtrs/file';
+import { readFileSync } from 'fs';
 
 // -------------------
 // Exported Interfaces
@@ -30,33 +29,15 @@ export interface IFusebitIssuer {
 // ----------------
 
 export class VersionService {
-  private input: IExecuteInput;
+  private static version: string;
 
-  private constructor(input: IExecuteInput) {
-    this.input = input;
-  }
-
-  public static async create(input: IExecuteInput) {
-    return new VersionService(input);
-  }
-
-  public async getVersion() {
-    let version;
-    try {
-      const path = join(__dirname, '..', '..', 'package.json');
-      const buffer = await readFile(path);
-      const content = buffer.toString();
-      const json = JSON.parse(content);
-      version = json.version;
-    } catch (error) {
-      if (!this.input.options.quiet) {
-        const header = 'Version Error';
-        const message = 'Unable to read the version of the current Fusebit CLI installation';
-        const formattedMessage = await Message.create({ header, message, kind: MessageKind.error });
-        await formattedMessage.write(this.input.io);
-      }
-      throw error;
+  public static getVersion() {
+    if (VersionService.version) {
+      return VersionService.version;
     }
-    return version;
+    const path = join(__dirname, '..', '..', 'package.json');
+    const content = readFileSync(path, { encoding: 'utf8' });
+    const json = JSON.parse(content);
+    return (VersionService.version = json.version);
   }
 }

--- a/docs/release-notes/fusebit-cli.md
+++ b/docs/release-notes/fusebit-cli.md
@@ -17,6 +17,12 @@ All public releases of the Fusebit CLI are documented here, including notable ch
 <!-- 1. TOC
 {:toc} -->
 
+## Version 1.16.1
+
+_Released 11/09/21_
+
+- **Enhancement.** Add support for specifying custom authorization account Id and authorization account Id override through FUSEBIT_AUTHORIZATION_ACCOUNT_ID and FUSEBIT_ACCOUNT_ID environment variables.
+
 ## Version 1.16.0
 
 _Released 10/21/21_

--- a/sdk/fusebit-profile-sdk/src/FusebitProfile.ts
+++ b/sdk/fusebit-profile-sdk/src/FusebitProfile.ts
@@ -461,7 +461,7 @@ export class FusebitProfile {
     return {
       accessToken,
       baseUrl: profile.baseUrl,
-      account: profile.account,
+      account: process.env.FUSEBIT_ACCOUNT_ID || profile.account,
       subscription: profile.subscription || undefined,
       boundary: profile.boundary || undefined,
       function: profile.function || undefined,


### PR DESCRIPTION
This adds support to Fuse CLI for specifying custom Fusebit authorization account Id and an override of the Fusebit account Id specified in the profile. Together with a profile that has (`*`, `/account/`) permission on a deployment (i.e. super-super admin), they enable us to inspect and diagnose any other Fusebit account using the CLI, in particular for self-service customers. For example, accessing logs of the customer who experienced the HTTP 500 when running an integration this morning looks like this:

```
fuse profile set on-prod
export FUSEBIT_AUTHORIZATION_ACCOUNT_ID=acc-124a0b2e6a1043d4
export FUSEBIT_ACCOUNT_ID=acc-805e28ecc0de428e
fuse log get all --subscription sub-1c41026fd4d943a0 --from=2021-11-09T00:17:33.588Z --to=2021-11-09T02:17:33.588Z --limit 150
```

Also, adding missing `--subscription` option to the `fuse connector` command. 