### PR TITLE
1048. Create entities from the feed examples

### DIFF
--- a/cli/fusebit-cli/package.json
+++ b/cli/fusebit-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/fusebit-cli",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "",
   "main": "libc/index.js",
   "bin": {
@@ -9,11 +9,7 @@
   "license": "MIT",
   "author": "https://fusebit.io",
   "packageAs": "@fusebit/cli",
-  "packageAssets": [
-    "template",
-    "README.md",
-    "LICENSE"
-  ],
+  "packageAssets": ["template", "README.md", "LICENSE"],
   "scripts": {
     "build": "tsc -b",
     "test": "jest --colors",

--- a/cli/fusebit-cli/src/commands/connector/ConnectorCommand.ts
+++ b/cli/fusebit-cli/src/commands/connector/ConnectorCommand.ts
@@ -8,6 +8,7 @@ import { ConnectorListCommand } from './ConnectorListCommand';
 import { ConnectorLogCommand } from './ConnectorLogCommand';
 import { ConnectorRemoveCommand } from './ConnectorRemoveCommand';
 import { IdentityCommand } from './identity/IdentityCommand';
+import { FeedCommand, IFeedOptions, FeedTypes } from '../feed';
 
 // ------------------
 // Internal Constants
@@ -36,6 +37,14 @@ const command: ICommand = {
   ],
 };
 
+const feedOptions: IFeedOptions = {
+  singular: 'connector',
+  capitalSingular: 'Connector',
+  plural: 'connectors',
+  capitalPlural: 'Connectors',
+  feedKey: FeedTypes.connector,
+};
+
 // ------------------
 // Internal Functions
 // ------------------
@@ -44,6 +53,7 @@ async function getSubCommands() {
   const subCommands = [];
   subCommands.push(await ConnectorInitCommand.create());
   subCommands.push(await ConnectorDeployCommand.create());
+  subCommands.push(await FeedCommand.create(feedOptions));
   subCommands.push(await ConnectorGetCommand.create());
   subCommands.push(await ConnectorListCommand.create());
   subCommands.push(await ConnectorLogCommand.create());

--- a/cli/fusebit-cli/src/commands/feed/FeedCommand.ts
+++ b/cli/fusebit-cli/src/commands/feed/FeedCommand.ts
@@ -1,0 +1,41 @@
+import { Command, ICommand } from '@5qtrs/cli';
+
+import { FeedListCommand } from './FeedListCommand';
+import { IFeedOptions } from './FeedOptions';
+
+// ------------------
+// Internal Constants
+// ------------------
+
+// ------------------
+// Internal Functions
+// ------------------
+
+async function getSubCommands(feedOptions: IFeedOptions) {
+  const subCommands = [];
+  subCommands.push(await FeedListCommand.create(feedOptions));
+  return subCommands;
+}
+
+// ----------------
+// Exported Classes
+// ----------------
+
+export class FeedCommand extends Command {
+  private constructor(cmd: ICommand) {
+    super(cmd);
+  }
+
+  public static async create(feedOptions: IFeedOptions) {
+    const command: ICommand = {
+      name: 'Feed',
+      cmd: 'feed',
+      summary: `Manage the ${feedOptions.capitalSingular} example feed`,
+      description: `Commands that use the public ${feedOptions.singular} feed`,
+      options: [],
+    };
+
+    command.subCommands = await getSubCommands(feedOptions);
+    return new FeedCommand(command);
+  }
+}

--- a/cli/fusebit-cli/src/commands/feed/FeedListCommand.ts
+++ b/cli/fusebit-cli/src/commands/feed/FeedListCommand.ts
@@ -1,0 +1,48 @@
+import { Command, IExecuteInput } from '@5qtrs/cli';
+
+import { FeedService } from '../../services';
+import { IFeedOptions } from './FeedOptions';
+
+// ------------------
+// Internal Constants
+// ------------------
+
+const command = {
+  name: 'List Feed Entries',
+  cmd: 'ls',
+  summary: 'List entries in the feed',
+  options: [
+    {
+      name: 'output',
+      aliases: ['o'],
+      description: "The format to display the output: 'pretty', 'json'",
+      default: 'pretty',
+    },
+  ],
+};
+
+// ----------------
+// Exported Classes
+// ----------------
+
+export class FeedListCommand extends Command {
+  public feedOptions: IFeedOptions;
+  private constructor(feedOptions: IFeedOptions) {
+    super(command);
+    this.feedOptions = feedOptions;
+  }
+
+  public static async create(feedOptions: IFeedOptions) {
+    return new FeedListCommand(feedOptions);
+  }
+
+  protected async onExecute(input: IExecuteInput): Promise<number> {
+    const feed = await FeedService.create(input);
+
+    await feed.loadFeed(this.feedOptions.feedKey);
+
+    await feed.displayFeed();
+
+    return 0;
+  }
+}

--- a/cli/fusebit-cli/src/commands/feed/FeedOptions.ts
+++ b/cli/fusebit-cli/src/commands/feed/FeedOptions.ts
@@ -1,0 +1,13 @@
+export enum FeedTypes {
+  all = 'all',
+  integration = 'integration',
+  connector = 'connector',
+}
+
+export interface IFeedOptions {
+  singular: string;
+  capitalSingular: string;
+  plural: string;
+  capitalPlural: string;
+  feedKey: FeedTypes;
+}

--- a/cli/fusebit-cli/src/commands/feed/index.ts
+++ b/cli/fusebit-cli/src/commands/feed/index.ts
@@ -1,0 +1,2 @@
+export { FeedCommand } from './FeedCommand';
+export { IFeedOptions, FeedTypes } from './FeedOptions';

--- a/cli/fusebit-cli/src/commands/integration/IntegrationCommand.ts
+++ b/cli/fusebit-cli/src/commands/integration/IntegrationCommand.ts
@@ -9,6 +9,7 @@ import { IntegrationRemoveCommand } from './IntegrationRemoveCommand';
 import { IntegrationEditCommand } from './IntegrationEditCommand';
 import { IntegrationTestCommand } from './IntegrationTestCommand';
 import { InstallCommand } from './install/InstallCommand';
+import { FeedCommand, IFeedOptions, FeedTypes } from '../feed';
 
 // ------------------
 // Internal Constants
@@ -34,6 +35,14 @@ const command: ICommand = {
   ],
 };
 
+const feedOptions: IFeedOptions = {
+  singular: 'integration',
+  capitalSingular: 'Integration',
+  plural: 'integrations',
+  capitalPlural: 'Integrations',
+  feedKey: FeedTypes.integration,
+};
+
 // ------------------
 // Internal Functions
 // ------------------
@@ -44,6 +53,7 @@ async function getSubCommands() {
   subCommands.push(await IntegrationGetCommand.create());
   subCommands.push(await IntegrationTestCommand.create());
   subCommands.push(await IntegrationDeployCommand.create());
+  subCommands.push(await FeedCommand.create(feedOptions));
   subCommands.push(await IntegrationEditCommand.create());
   subCommands.push(await IntegrationListCommand.create());
   subCommands.push(await IntegrationLogCommand.create());

--- a/cli/fusebit-cli/src/commands/integration/IntegrationInitCommand.ts
+++ b/cli/fusebit-cli/src/commands/integration/IntegrationInitCommand.ts
@@ -1,7 +1,9 @@
 import { join } from 'path';
 import { Command, ArgType, IExecuteInput } from '@5qtrs/cli';
-import { ExecuteService, IntegrationService } from '../../services';
+import { ExecuteService, ConnectorService, IntegrationService, FeedService } from '../../services';
 import { Text } from '@5qtrs/text';
+
+import { FeedTypes } from '../feed';
 
 // ------------------
 // Internal Constants
@@ -27,6 +29,11 @@ const command = {
       aliases: ['d'],
       description: 'A path to the directory with the integration source code to deploy.',
       defaultText: 'current directory',
+    },
+    {
+      name: 'feed',
+      aliases: ['f'],
+      description: 'Initialize the directory with this example from the feed',
     },
     {
       name: 'quiet',
@@ -60,6 +67,7 @@ export class IntegrationInitCommand extends Command {
 
   protected async onExecute(input: IExecuteInput): Promise<number> {
     const sourceDir = input.options.dir as string;
+    const feed = input.options.feed as string;
 
     const integrationService = await IntegrationService.create(input);
     const executeService = await ExecuteService.create(input);
@@ -67,10 +75,32 @@ export class IntegrationInitCommand extends Command {
     await executeService.newLine();
 
     const sourcePath = sourceDir ? join(process.cwd(), sourceDir) : process.cwd();
-    const integration = await integrationService.createNewSpec();
-    await integrationService.writeDirectory(sourcePath, integration);
 
-    await integrationService.displayEntities([integration], true);
+    if (!feed) {
+      const integration = await integrationService.createNewSpec();
+      await integrationService.writeDirectory(sourcePath, integration);
+
+      await integrationService.displayEntities([integration], true);
+      return 0;
+    }
+
+    const connectorService = await ConnectorService.create(input);
+    const feedService = await FeedService.create(input);
+    await feedService.loadFeed(FeedTypes.integration);
+    const result = await feedService.renderById(feed);
+
+    if (input.options.output === 'json') {
+      input.io.writeLineRaw(JSON.stringify(result, null, 2));
+      return 0;
+    }
+
+    for (const entity of result.integrations) {
+      await integrationService.writeDirectory(join(sourcePath, entity.id), entity);
+    }
+
+    for (const entity of result.connectors) {
+      await connectorService.writeDirectory(join(sourcePath, entity.id), entity);
+    }
 
     return 0;
   }

--- a/cli/fusebit-cli/src/services/FeedService.ts
+++ b/cli/fusebit-cli/src/services/FeedService.ts
@@ -1,0 +1,250 @@
+import superagent from 'superagent';
+import Mustache from 'mustache';
+
+import { randomBytes } from 'crypto';
+
+import { Text } from '@5qtrs/text';
+import { IExecuteInput } from '@5qtrs/cli';
+import { IFusebitExecutionProfile } from '@5qtrs/fusebit-profile-sdk';
+import { EntityType, IIntegration, IIntegrationData, IConnector, IConnectorData } from '@fusebit/schema';
+
+import { ExecuteService } from './ExecuteService';
+import { ProfileService } from './ProfileService';
+
+import { FeedTypes } from '../commands/feed/FeedOptions';
+
+const FEED_BASE_URL = process.env.FEED_BASE_URL || 'https://manage.fusebit.io/feed/';
+
+interface IEntity<T extends EntityType> {
+  entityType: T;
+  id: string;
+  isApplication?: boolean;
+  data: T extends EntityType.connector ? IConnectorData : IIntegrationData;
+  tags: {
+    [key: string]: string;
+  };
+}
+
+interface IFeed {
+  id: string;
+  feedSource: string;
+  name: string;
+  description: string;
+  tags: {
+    service: string;
+    feed: string;
+  };
+  resources: {
+    configureAppDocUrl: string;
+  };
+  configuration: {
+    entities: Record<string, IEntity<EntityType.connector> | IEntity<EntityType.integration>>;
+  };
+}
+
+interface IFeedArtifacts {
+  connectors: IConnector[];
+  integrations: IIntegration[];
+}
+
+const walkObjectStrings = (obj: any, func: (value: string) => string): any => {
+  Object.entries(obj).forEach(([key, value]) => {
+    if (typeof value === 'string') {
+      obj[key] = func(value);
+    } else if (typeof value === 'object') {
+      walkObjectStrings(value, func);
+    }
+  });
+  return obj;
+};
+
+export class FeedService {
+  public feed: IFeed[] = [];
+
+  public input: IExecuteInput;
+  public executeService: ExecuteService;
+  public profile: IFusebitExecutionProfile;
+
+  constructor(input: IExecuteInput, executeService: ExecuteService, profile: IFusebitExecutionProfile) {
+    this.input = input;
+    this.executeService = executeService;
+    this.profile = profile;
+  }
+
+  public static async create(input: IExecuteInput) {
+    const executeService = await ExecuteService.create(input);
+    const profileService = await ProfileService.create(input);
+    const profile = await profileService.getExecutionProfile(['account', 'subscription']);
+
+    return new FeedService(input, executeService, profile);
+  }
+
+  public async loadFeed(feedType: FeedTypes) {
+    let feed: IFeed[] = [];
+
+    if (feedType === FeedTypes.all || feedType === FeedTypes.integration) {
+      const urlFeed: IFeed[] = await this.loadFeedByUrl(FEED_BASE_URL + `integrationsFeed.json`);
+      feed = urlFeed.map((f: IFeed) => ({ ...f, feedSource: 'integration' }));
+    }
+
+    if (feedType === FeedTypes.all || feedType === FeedTypes.connector) {
+      const urlFeed = await this.loadFeedByUrl(FEED_BASE_URL + `connectorsFeed.json`);
+      feed = [...feed, ...urlFeed.map((f: IFeed) => ({ ...f, feedSource: 'connector' }))];
+    }
+
+    this.feed = feed;
+    return feed;
+  }
+
+  public async loadFeedByUrl(url: string) {
+    const response = await superagent.get(url);
+    return response.body;
+  }
+
+  public async renderById(feedId: string): Promise<IFeedArtifacts> {
+    const feed = this.feed.find((entry) => entry.id === feedId);
+    if (feed) {
+      return this.render(feed);
+    }
+    await this.executeService.error('Feed Error', `Unknown feed id ${feedId}`);
+    throw new Error('never');
+  }
+
+  protected createGlobals(feed: IFeed) {
+    const global: any = {
+      entities: {},
+      consts: {
+        accountId: this.profile.account,
+        subscriptionId: this.profile.subscription,
+        endpoint: this.profile.baseUrl,
+        integrationId: () => {
+          const integration: any = Object.entries(feed.configuration.entities).find(
+            ([, entity]) => entity.entityType === EntityType.integration
+          );
+          return integration ? global.entities[integration[0]]?.id() || integration[1].id : '';
+        },
+        random: () => {
+          return randomBytes(32).toString('hex');
+        },
+        feed: { ...JSON.parse(JSON.stringify(feed)) },
+      },
+    };
+
+    return global;
+  }
+
+  protected makeEntityId<T extends EntityType>(entity: IEntity<T>) {
+    return `${entity.entityType === EntityType.integration ? 'my-integration' : 'my-connector'}-${Math.floor(
+      Math.random() * 1000
+    )}`;
+  }
+
+  protected getCommonTags(feed: IFeed) {
+    return {
+      'fusebit.feedId': feed.id,
+      'fusebit.feedType': feed.feedSource,
+    };
+  }
+
+  protected async render(feed: IFeed): Promise<IFeedArtifacts> {
+    // Disable html escaping because these values are all trusted
+    Mustache.escape = (s: string) => s;
+    const customTags: any = ['<%', '%>'];
+
+    const global = this.createGlobals(feed);
+
+    if (!feed.configuration?.entities) {
+      throw new Error(`Not a deployable feed (${feed.id})`);
+    }
+
+    const entityIdCache: Record<string, { id?: string }> = {};
+
+    Object.entries(feed.configuration.entities).forEach(([name, entity]) => {
+      if (!entityIdCache[name]) {
+        entityIdCache[name] = {};
+      }
+
+      // Use global.entities to allow inter-entity references (for acquiring id's, for example).
+      global.entities[name] = {
+        id: () => {
+          // Only create a new random ID once for an entry
+          if (!entityIdCache[name].id) {
+            entityIdCache[name].id = this.makeEntityId(entity);
+          }
+          return entityIdCache[name].id;
+        },
+      };
+    });
+
+    // Now parse each entity, replacing its strings as appropriate
+    Object.entries(feed.configuration.entities).forEach(([name, entity]) => {
+      const view = {
+        // Enable 'this' to always be used to get the current entities id and name.
+        this: {
+          id: () => global.entities[name].id(),
+          name,
+        },
+
+        // Otherwise, expose the global datapoints and utility methods.
+        global,
+      };
+
+      // Walk the entire object, running the mustache across any strings found
+      feed.configuration.entities[name] = walkObjectStrings(entity, (value: string) =>
+        Mustache.render(value, view, {}, customTags)
+      );
+    });
+
+    // Convert into something that can be published or serialized to disk.
+    const result: IFeedArtifacts = {
+      integrations: [],
+      connectors: [],
+    };
+
+    const commonTags = this.getCommonTags(feed);
+
+    Object.values(feed.configuration.entities).forEach((entity) => {
+      if (entity.entityType === EntityType.integration) {
+        const element: IIntegration = {
+          accountId: this.profile!.account,
+          subscriptionId: this.profile.subscription || '',
+          ...entity,
+          data: entity.data as IIntegrationData,
+          tags: commonTags,
+        };
+        result.integrations.push(element);
+      }
+      if (entity.entityType === EntityType.connector) {
+        const element: IConnector = {
+          accountId: this.profile!.account,
+          subscriptionId: this.profile!.subscription || '',
+          ...entity,
+          data: entity.data as IConnectorData,
+          tags: commonTags,
+        };
+        result.connectors.push(element);
+      }
+    });
+
+    return result;
+  }
+
+  public async displayFeed() {
+    const visibleEntries = this.feed.filter((entry) => entry.configuration.entities);
+
+    if (this.input.options.output === 'json') {
+      // Output a json dump of the available options
+      this.input.io.writeLineRaw(JSON.stringify(visibleEntries, null, 2));
+      return;
+    }
+
+    // Output a pretty table of results
+    await this.executeService.result(Text.cyan('Name'), Text.cyan('Description'));
+    for (const entry of visibleEntries) {
+      await this.executeService.result(
+        Text.bold(entry.name),
+        Text.create(['Key: ', Text.bold(entry.id), Text.eol(), entry.description.split('\n')[0]])
+      );
+    }
+  }
+}

--- a/cli/fusebit-cli/src/services/index.ts
+++ b/cli/fusebit-cli/src/services/index.ts
@@ -8,3 +8,4 @@ export { ConnectorService } from './ConnectorService';
 export { IntegrationService } from './IntegrationService';
 export { StorageService } from './StorageService';
 export { LogService } from './LogService';
+export { FeedService } from './FeedService';

--- a/docs/release-notes/fusebit-cli.md
+++ b/docs/release-notes/fusebit-cli.md
@@ -17,6 +17,12 @@ All public releases of the Fusebit CLI are documented here, including notable ch
 <!-- 1. TOC
 {:toc} -->
 
+## Version 1.18.0
+
+_Released 11/15/21_
+
+- **Enhancement.** Initialize an example from a published entry in the integration or connector feeds.
+
 ## Version 1.17.0
 
 _Released 11/14/21_


### PR DESCRIPTION
```
% node libc/index.js integration feed ls
Name              │  Description

Atlassian         │  Key: confluence
Confluence        │  Integrating with Confluence is easy with Fusebit! This
                  │  example lets you list the accessible resources in your
                  │  customer's Confluence account.

GitHub App        │  Key: githubapp
                  │  Integrating with GitHub is easy with Fusebit!

GitHub OAuth App  │  Key: githuboauth
                  │  Integrating with GitHub OAuth App is easy with Fusebit!

HubSpot Contacts  │  Key: hubspot-crm-contacts
sync              │  Integrating with HubSpot is easy with Fusebit! This example
                  │  lets you list Contacts in your customer's HubSpot instance.

Atlassian Jira    │  Key: jira
                  │  Integrating with Jira is easy with Fusebit! This example
                  │  lets you list the accessible resources in your customer's
                  │  Jira account.

Linear            │  Key: linear
                  │  Linear streamlines software projects, sprints, tasks, and
                  │  bug tracking. This integration lets you

PagerDuty         │  Key: pagerduty
                  │  Integrating with PagerDuty is easy with Fusebit! This
                  │  example lets you list incidents in your customer's
                  │  PagerDuty instance.

Salesforce        │  Key: salesforce
                  │  Integrating with Salesforce is easy with Fusebit! This
                  │  example lets you list Contacts in your customer's
                  │  Salesforce instance.

Slack Bot         │  Key: slack-bot
                  │  Building a simple Slack bot is easy with Fusebit! This
                  │  example lets you send messages from your system to a
                  │  channel in your customer's Slack instance.

```

```
% node libc/index.js integration init -d x -f slack-bot

Integration       │  The Integration was downloaded to the
                  │  /Users/gambit/p/q5/cli/fusebit-cli/x/my-integration-820
                  │  directory and the following files were written to disk:
                  │
                  │  • fusebit.json
                  │  • package.json
                  │  • ./integration.js
                  │  • README.md
                  │

Connector         │  The Connector was downloaded to the
                  │  /Users/gambit/p/q5/cli/fusebit-cli/x/my-connector-39
                  │  directory and the following files were written to disk:
                  │
                  │  • fusebit.json
                  │  • package.json
                  │

```

```
% node libc/index.js connector init -d x -f slack

Connector         │  The Connector was downloaded to the
                  │  /Users/gambit/p/q5/cli/fusebit-cli/x/my-connector-569
                  │  directory and the following files were written to disk:
                  │
                  │  • fusebit.json
                  │  • package.json
                  │

```