### PR TITLE
Iterate npm search until entries are found

### DIFF
--- a/docs/release-notes/fusebit-http-api.md
+++ b/docs/release-notes/fusebit-http-api.md
@@ -17,6 +17,12 @@ All public releases of the Fusebit HTTP API are documented here, including notab
 <!-- 1. TOC
 {:toc} -->
 
+## Version 1.29.1
+
+_Released 11/15/21_
+
+- **BugFix.** Internal npm package registry search returns the first 20 entries, and propagates `next` correctly.
+
 ## Version 1.29.0
 
 _Released 11/14/21_

--- a/lib/server/npm/src/search.ts
+++ b/lib/server/npm/src/search.ts
@@ -2,18 +2,37 @@ import { Response, Request } from 'express';
 import { tarballUrlUpdate } from './package';
 import { IFunctionApiRequest } from './request';
 
+/*
+ * Proper npm search is super primitive - it does a search and returns only the top 20 items, with no
+ * particularly well documented support for any pagination, especially not in the client itself.
+ *
+ * As a stop-gap to spending ages figuring out exactly how to rig this, loop until either `count` entries have
+ * been found or there's no further next parameters available, filling up an entry even when empty pages would
+ * normally be returned due to DynamoDB not returning any valid entries.
+ */
 const searchGet = () => {
   return async (reqBase: Request, res: Response, next: any) => {
     const req = reqBase as IFunctionApiRequest;
-    const count = req.query.count ? Number(req.query.count) : 100;
-    const searchNext = req.query.next ? (req.query.next as string) : undefined;
+    const count = req.query.count ? Number(req.query.count) : 20;
+    let searchNext = req.query.next ? (req.query.next as string) : undefined;
+
     try {
-      const results = await req.registry.search(req.query.text as string, count, searchNext);
+      const objects = [];
+      let results;
+      do {
+        results = await req.registry.search(req.query.text as string, count, searchNext);
 
-      for (const pkg of results.objects) {
-        tarballUrlUpdate(req, pkg.package);
-      }
+        for (const pkg of results.objects) {
+          tarballUrlUpdate(req, pkg.package);
+        }
 
+        objects.push(...results.objects);
+
+        searchNext = results.next;
+      } while (searchNext && objects.length < count);
+
+      results.objects = objects;
+      results.total = objects.length;
       return res.status(200).json(results);
     } catch (e) {
       return next(e);

--- a/lib/server/registry/src/AwsRegistry.ts
+++ b/lib/server/registry/src/AwsRegistry.ts
@@ -328,7 +328,9 @@ class AwsRegistry implements IRegistryStore {
       objects: manifests.map((manifest) => ({ package: manifest })),
       total: items.length,
       time: new Date().toUTCString(),
-      next: result.LastEvaluatedKey,
+      next: result.LastEvaluatedKey
+        ? Buffer.from(JSON.stringify(result.LastEvaluatedKey), 'utf8').toString('base64')
+        : undefined,
     };
   }
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.29.0",
+  "version": "1.29.1",
   "private": true,
   "org": "5qtrs",
   "engines": {


### PR DESCRIPTION
Also, correctly propagate `next` parameters from one call to the next, which wasn't happening at all previously.

Note: this requires particular conditions in DynamoDB to encounter, which is why there aren't any specific tests for it.  On the plus side, we now know for a fact that the jenkins installation will encounter it on every run! :D