### PR TITLE
Improved support for module and function builders with everynode

### DIFF
--- a/api/function-api/test/v1/layers.test.ts
+++ b/api/function-api/test/v1/layers.test.ts
@@ -26,7 +26,7 @@ beforeEach(() => {
 const reflectVersion = (node: string, dependencies?: object) => ({
   nodejs: {
     files: {
-      'package.json': { engines: { node, dependencies } },
+      'package.json': { engines: { node }, ...{ dependencies } },
       'index.js': 'module.exports = async (ctx) => ({ body: process.version });',
     },
   },

--- a/docs/release-notes/fusebit-http-api.md
+++ b/docs/release-notes/fusebit-http-api.md
@@ -17,6 +17,12 @@ All public releases of the Fusebit HTTP API are documented here, including notab
 <!-- 1. TOC
 {:toc} -->
 
+## Version 1.35.1
+
+_Released 2/18/22_
+
+- **Bugfix.** Improved support for module and function builders for custom Node.js versions.
+
 ## Version 1.35.0
 
 _Released 2/16/22_

--- a/lib/server/function-lambda/src/create_function_worker.js
+++ b/lib/server/function-lambda/src/create_function_worker.js
@@ -1033,7 +1033,7 @@ function create_function_builder(options, cb) {
   let create_builder_params = {
     FunctionName: functionName,
     Description: Constants.get_function_builder_description(options),
-    ...get_runtime_options(options.compute.runtime, options.internal.existing.compute?.runtime),
+    ...get_runtime_options(options.compute.runtime),
     Handler: 'index.buildFunction',
     MemorySize: +process.env.LAMBDA_BUILDER_MEMORY_SIZE || 2048,
     Timeout: +process.env.LAMBDA_BUILDER_TIMEOUT || 120,
@@ -1061,7 +1061,7 @@ function create_module_builder(name, ctx, cb) {
   let create_builder_params = {
     FunctionName: functionName,
     Description: Constants.get_module_builder_description(ctx, name, ctx.options.internal.resolved_dependencies[name]),
-    ...get_runtime_options(ctx.options.compute.runtime, ctx.options.internal.existing.compute?.runtime),
+    ...get_runtime_options(ctx.options.compute.runtime),
     Handler: 'index.buildModule',
     MemorySize: +process.env.LAMBDA_MODULE_BUILDER_MEMORY_SIZE || 2048,
     Timeout: +process.env.LAMBDA_MODULE_BUILDER_TIMEOUT || 120,

--- a/lib/server/function-lambda/src/layers.json
+++ b/lib/server/function-lambda/src/layers.json
@@ -510,7 +510,7 @@
     "17.3.0": "arn:aws:lambda:us-west-1:072686360478:layer:node-17_3_0:1",
     "17.3.1": "arn:aws:lambda:us-west-1:072686360478:layer:node-17_3_1:1",
     "17.4.0": "arn:aws:lambda:us-west-1:072686360478:layer:node-17_4_0:4",
-    "17.5.0": "arn:aws:lambda:us-west-1:072686360478:layer:node-17_5_0:6"
+    "17.5.0": "arn:aws:lambda:us-west-1:072686360478:layer:node-17_5_0:7"
   },
   "us-west-2": {
     "11.0.0": "arn:aws:lambda:us-west-2:072686360478:layer:node-11_0_0:1",
@@ -681,7 +681,7 @@
     "17.3.0": "arn:aws:lambda:us-west-2:072686360478:layer:node-17_3_0:1",
     "17.3.1": "arn:aws:lambda:us-west-2:072686360478:layer:node-17_3_1:1",
     "17.4.0": "arn:aws:lambda:us-west-2:072686360478:layer:node-17_4_0:14",
-    "17.5.0": "arn:aws:lambda:us-west-2:072686360478:layer:node-17_5_0:9"
+    "17.5.0": "arn:aws:lambda:us-west-2:072686360478:layer:node-17_5_0:11"
   },
   "af-south-1": {
     "11.0.0": "arn:aws:lambda:af-south-1:072686360478:layer:node-11_0_0:1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.35.0",
+  "version": "1.35.1",
   "private": true,
   "org": "5qtrs",
   "engines": {


### PR DESCRIPTION
This is a minor change that helps with our development scenarios - making sure we always specify layers when creating Lambdas for module and function builders for custom Node versions.