### PR TITLE
Allow tasks to run more than 120s

### DIFF
--- a/cli/fusebit-ops-cli/package.json
+++ b/cli/fusebit-ops-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@5qtrs/fusebit-ops-cli",
-  "version": "1.38.13",
+  "version": "1.38.14",
   "description": "The Fusebit Platform Operations CLI",
   "main": "libc/index.js",
   "license": "UNLICENSED",
@@ -56,5 +56,7 @@
     "@types/jszip": "^3.4.1",
     "@types/rimraf": "^3.0.0"
   },
-  "bundledDependencies": ["@fusebit/schema"]
+  "bundledDependencies": [
+    "@fusebit/schema"
+  ]
 }

--- a/docs/release-notes/fusebit-http-api.md
+++ b/docs/release-notes/fusebit-http-api.md
@@ -17,6 +17,12 @@ All public releases of the Fusebit HTTP API are documented here, including notab
 <!-- 1. TOC
 {:toc} -->
 
+## Version 1.40.7
+
+_Released 7/27/22_
+
+- **Bugfix** Fix logging of results for tasks running longer than 120 seconds.
+
 ## Version 1.40.6
 
 _Released 7/22/22_

--- a/docs/release-notes/fusebit-ops-cli.md
+++ b/docs/release-notes/fusebit-ops-cli.md
@@ -18,6 +18,12 @@ All public releases of the Fusebit Operations CLI are documented here, including
 {:toc}
 -->
 
+## Version 1.38.14
+
+_Released 7/27/22_
+
+- **Bugfix** Fix logging of results for tasks running longer than 120 seconds.
+
 ## Version 1.38.13
 
 _Released 7/15/22_

--- a/lib/runtime/common/src/common.js
+++ b/lib/runtime/common/src/common.js
@@ -4,9 +4,10 @@ exports.realtime_logs_enabled = !process.env.LOGS_DISABLE;
 
 exports.Lambda = new AWS.Lambda({
   apiVersion: '2015-03-31',
+  maxRetries: 0,
   httpOptions: {
-    // Allow for at max 121-second connection to lambda API, so 120-second execution of lambda won't timeout in SDK.
-    timeout: 121 * 1000,
+    // Allow for at max 901-second connection to lambda API, so 900-second execution of lambda won't timeout in SDK.
+    timeout: 901 * 1000,
   },
 });
 

--- a/lib/runtime/common/src/invoke_function.js
+++ b/lib/runtime/common/src/invoke_function.js
@@ -111,8 +111,7 @@ const invoke_function_core = (options, version, cb) => {
     InvocationType: 'RequestResponse',
     LogType: 'Tail',
   };
-
-  return Common.Lambda.invoke(invoke_params, (e, d) => {
+  const req = Common.Lambda.invoke(invoke_params, (e, d) => {
     if (d && d.Payload) {
       try {
         d.Payload = JSON.parse(d.Payload);
@@ -123,6 +122,12 @@ const invoke_function_core = (options, version, cb) => {
     }
     return cb(e, d);
   });
+  if (req.httpRequest.stream) {
+    // To enable long tunning tasks, set TCP keep alive to work around the 350s
+    // limit on inactive TCP connections on AWS NAT
+    // (see https://github.com/aws/aws-sdk-js-v3/issues/3624)
+    req.httpRequest.stream.setSocketKeepAlive(true, 10000);
+  }
 };
 
 const schedule_function_core = async (req, ctx, cb) => {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.40.6",
+  "version": "1.40.7",
   "private": true,
   "org": "5qtrs",
   "engines": {
@@ -80,7 +80,10 @@
     "yarn": "^1.12.3"
   },
   "workspaces": {
-    "nohoist": ["**/lambda-*", "**/lambda-*/**"],
+    "nohoist": [
+      "**/lambda-*",
+      "**/lambda-*/**"
+    ],
     "packages": [
       "tool/tool-config",
       "tool/workspace",


### PR DESCRIPTION
1. Fix the 120s limit on long-running tasks by increasing client-side AWS SDK timeout from 121s to 901s. 
2. Fix the 350s limit on long-running tasks implied by AWS NAT 250s TCP inactivity timeout by enabling TCP keep-alive for Lambda execution requests. 
3. Turn off retries of Lambda API calls to prevent re-running user Lambdas on Fusebit infrastructure errors. 