### PR TITLE
Remove invalid entity.entityType usage in BaseEntityService

### DIFF
--- a/api/function-api/src/routes/service/BaseEntityService.ts
+++ b/api/function-api/src/routes/service/BaseEntityService.ts
@@ -101,7 +101,7 @@ export default abstract class BaseEntityService<E extends Model.IEntity, F exten
               authorization: [
                 {
                   action: 'function:schedule',
-                  resource: `/account/${entity.accountId}/subscription/${entity.subscriptionId}/boundary/${entity.entityType}/function/${entity.id}/`,
+                  resource: `/account/${entity.accountId}/subscription/${entity.subscriptionId}/boundary/${this.entityType}/function/${entity.id}/`,
                 },
               ],
               functionPermissions,
@@ -120,7 +120,7 @@ export default abstract class BaseEntityService<E extends Model.IEntity, F exten
     // Add the baseUrl to the configuration.
     const config = {
       ...functionConfig,
-      mountUrl: `/v2/account/${entity.accountId}/subscription/${entity.subscriptionId}/${entity.entityType}/${entity.id}`,
+      mountUrl: `/v2/account/${entity.accountId}/subscription/${entity.subscriptionId}/${this.entityType}/${entity.id}`,
     };
 
     const security = this.getFunctionSecuritySpecification(entity);

--- a/docs/release-notes/fusebit-http-api.md
+++ b/docs/release-notes/fusebit-http-api.md
@@ -17,7 +17,7 @@ All public releases of the Fusebit HTTP API are documented here, including notab
 <!-- 1. TOC
 {:toc} -->
 
-## Version 1.40.8
+## Version 1.40.9
 
 _Released 7/31/22_
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.40.8",
+  "version": "1.40.9",
   "private": true,
   "org": "5qtrs",
   "engines": {


### PR DESCRIPTION
entity.entityType is only valid during initial object creation;
subsequent builds do not have that value set, resulting in `undefined`
strings embedded in the configuration.